### PR TITLE
chore: setup GitHub Flow workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## 变更说明
+<!-- 描述这个 PR 做了什么，解决了什么问题 -->
+
+## 变更类型
+- [ ] `feat`: 新功能
+- [ ] `fix`: Bug 修复
+- [ ] `chore`: 依赖/配置/格式变更
+- [ ] `docs`: 文档更新
+- [ ] `refactor`: 重构（无功能变化）
+
+## 测试
+- [ ] `cargo test` 通过
+- [ ] `cargo clippy -- -D warnings` 通过
+- [ ] `cargo fmt -- --check` 通过
+
+## 备注
+<!-- 其他需要 reviewer 了解的信息 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches-ignore: []   # Run CI on all branches
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## 变更说明

建立标准 GitHub Flow 工作流规范：
- CI 改为对所有分支触发（不只是 main），feature branch push 后即可看到 CI 结果
- 添加 PR 模板，每次提 PR 自动带出 checklist

## 变更类型
- [x] `chore`: 依赖/配置/格式变更

## 测试
- [x] `cargo test` 通过
- [x] `cargo clippy -- -D warnings` 通过
- [x] `cargo fmt -- --check` 通过

## 备注

合并后还需在 GitHub Settings 手动开启 Branch Protection：
- Settings → Branches → Add rule → `main`
- 勾选 Require PR + Require status checks (build/lint/docs)