### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore: []   # Run CI on all branches


### PR DESCRIPTION
Potential fix for [https://github.com/hiyenwong/sqlite-knowledge-graph/security/code-scanning/3](https://github.com/hiyenwong/sqlite-knowledge-graph/security/code-scanning/3)

In general, the fix is to add a `permissions` block specifying the minimal required scopes for the `GITHUB_TOKEN`. For this workflow, the jobs only need to read the repository contents and use caching; they do not need to write to code, issues, or pull requests. The safest and simplest fix is to define `permissions: contents: read` at the workflow root so it applies to all jobs.

Concretely, edit `.github/workflows/ci.yml` and insert a `permissions` section near the top, after `name: CI` (line 1) and before the `on:` block (line 3). The new block will be:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed; this is entirely a configuration change within the YAML workflow. This will restrict the `GITHUB_TOKEN` to read-only contents for all three jobs (`build`, `lint`, and `docs`) unless overridden in a specific job, which we are not doing here, preserving existing behavior while reducing privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
