### PR TITLE
feat: Async API via tokio spawn_blocking (v0.11.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,15 @@ jobs:
     
     - name: Build
       run: cargo build --verbose
-    
+
+    - name: Build (async feature)
+      run: cargo build --features async --verbose
+
     - name: Run tests
       run: cargo test --verbose
+
+    - name: Run tests (async feature)
+      run: cargo test --features async --verbose
 
   lint:
     runs-on: ubuntu-latest
@@ -60,6 +66,9 @@ jobs:
     
     - name: Run clippy
       run: cargo clippy -- -D warnings
+
+    - name: Run clippy (async feature)
+      run: cargo clippy --features async -- -D warnings
 
   docs:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ algorithms            vector
     (检索增强生成框架)
           ↓
          export
+          ↓
+      async_kg  ← feature = "async"
+  (spawn_blocking 异步包装层)
 ```
 
 详见 [docs/architecture/README.md](docs/architecture/README.md)
@@ -37,10 +40,11 @@ algorithms            vector
 |----|------|----------|------|
 | schema | `src/schema.rs` + `src/migrate.rs` | — | 稳定 |
 | graph | `src/graph/` | [docs/design/graph.md](docs/design/graph.md) | 稳定 |
-| algorithms | `src/algorithms/` | [docs/design/algorithms.md](docs/design/algorithms.md) | P0 Bug |
-| vector | `src/vector/` | [docs/design/vector.md](docs/design/vector.md) | P0 Bug |
-| rag | `src/rag/` | [docs/design/rag.md](docs/design/rag.md) | 空壳 |
+| algorithms | `src/algorithms/` | [docs/design/algorithms.md](docs/design/algorithms.md) | 稳定 |
+| vector | `src/vector/` | [docs/design/vector.md](docs/design/vector.md) | 稳定 |
+| rag | `src/rag/` | [docs/design/rag.md](docs/design/rag.md) | 稳定 |
 | export | `src/export/` | — | 稳定 |
+| async_kg | `src/async_kg/` | — | 稳定（feature = "async"） |
 
 ## Critical Constraints
 
@@ -72,8 +76,10 @@ algorithms            vector
 |--------|------|------|
 | 编译 | `cargo build` | 零错误 |
 | 测试 | `cargo test` | 全通过 |
+| 异步测试 | `cargo test --features async` | 全通过 |
 | 格式 | `cargo fmt -- --check` | 零 diff |
 | Lint | `cargo clippy -- -D warnings` | 零警告 |
+| Async Lint | `cargo clippy --features async -- -D warnings` | 零警告 |
 
 ## Agent Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +724,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simba"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1238,7 @@ dependencies = [
  "sqlite-loadable",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 
@@ -1352,6 +1380,32 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "test-ut
 name = "turboquant_bench"
 harness = false
 
+[[example]]
+name = "async_demo"
+required-features = ["async"]
+
 [features]
 default = []
 # Enable bundled SQLite (conflicts with sqlite-loadable extension)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,13 @@ rand_distr = "0.4"
 ndarray = "0.15"
 nalgebra = "0.33"
 chrono = "0.4.44"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "process", "io-util"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.10"
 shellexpand = "3.1"
 criterion = "0.5"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "test-util"] }
 
 [[bench]]
 name = "turboquant_bench"
@@ -44,6 +46,8 @@ harness = false
 default = []
 # Enable bundled SQLite (conflicts with sqlite-loadable extension)
 bundled = ["rusqlite/bundled"]
+# Enable async API via tokio (not suitable for cdylib extension use case)
+async = ["dep:tokio"]
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -388,6 +388,64 @@ CREATE TABLE kg_hyperedge_entities (
 CREATE INDEX idx_hyperedge_entities_entity ON kg_hyperedge_entities(entity_id);
 ```
 
+## Async API
+
+Requires the `async` feature (opt-in, zero overhead when not enabled):
+
+```toml
+[dependencies]
+sqlite-knowledge-graph = { git = "...", features = ["async"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+All blocking SQLite operations are dispatched to `tokio::task::spawn_blocking`, keeping the async executor thread free. The async API mirrors the sync API but takes **owned values** (required for `'static` closures).
+
+```rust
+use sqlite_knowledge_graph::{AsyncKnowledgeGraph, Entity, Relation};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync()?;
+
+    // Concurrent inserts
+    let handles: Vec<_> = (0..10).map(|i| {
+        let kg = std::sync::Arc::new(&kg);  // share across tasks
+        tokio::spawn(async move {
+            kg.insert_entity(Entity::new("paper", format!("Paper {i}"))).await
+        })
+    }).collect();
+
+    // CRUD
+    let entity = Entity::new("paper", "Async Paper");
+    let id = kg.insert_entity(entity).await?;
+    let retrieved = kg.get_entity(id).await?;
+
+    // Graph algorithms (CPU-bound, runs off executor)
+    let scores = kg.kg_pagerank(None).await?;
+    let communities = kg.kg_louvain().await?;
+
+    // Vector search
+    let results = kg.kg_semantic_search(query_embedding, 10).await?;
+
+    // Convert existing sync instance
+    let sync_kg = KnowledgeGraph::open("my.db")?;
+    let async_kg = sync_kg.into_async();
+
+    Ok(())
+}
+```
+
+Async embedding generation (non-blocking Python subprocess):
+
+```rust
+use sqlite_knowledge_graph::AsyncEmbeddingGenerator;
+
+let gen = AsyncEmbeddingGenerator::new();
+let embeddings = gen.generate_embeddings(vec!["hello world".into()]).await?;
+```
+
+> **Note**: `AsyncKnowledgeGraph` serialises all operations through a single `Mutex`. For read-heavy concurrent workloads, open multiple instances on the same WAL-mode file.
+
 ## Performance
 
 Benchmarks on a knowledge graph with 2,619 entities and 1.48M relations:
@@ -422,7 +480,7 @@ Benchmarks on a knowledge graph with 2,619 entities and 1.48M relations:
 | **Higher-order Relations (Hyperedge)** | ✅ **Complete (v0.10.0)** |
 | **Paper-driven RAG Engine** | ✅ **Complete (v0.10.1)** |
 | Graph Visualization Export (D3/DOT) | ✅ Complete |
-| Async API | ⏳ Planned |
+| **Async API (tokio)** | ✅ **Complete (v0.11.0)** |
 
 ## Testing
 
@@ -437,7 +495,7 @@ cargo test -- --nocapture
 cargo test test_pagerank
 ```
 
-Current test coverage: **95 unit tests + 2 integration tests passing**
+Current test coverage: **122 unit tests + 14 integration tests passing** (includes 11 async tests)
 
 ## Projects Using This Library
 

--- a/README.md
+++ b/README.md
@@ -405,11 +405,11 @@ use sqlite_knowledge_graph::{AsyncKnowledgeGraph, Entity, Relation};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let kg = AsyncKnowledgeGraph::open_in_memory_sync()?;
+    let kg = std::sync::Arc::new(AsyncKnowledgeGraph::open_in_memory_sync()?);
 
     // Concurrent inserts
     let handles: Vec<_> = (0..10).map(|i| {
-        let kg = std::sync::Arc::new(&kg);  // share across tasks
+        let kg = std::sync::Arc::clone(&kg);
         tokio::spawn(async move {
             kg.insert_entity(Entity::new("paper", format!("Paper {i}"))).await
         })

--- a/docs/quality/domains.md
+++ b/docs/quality/domains.md
@@ -1,17 +1,18 @@
 # Quality Status by Domain
 
-Last updated: 2026-04-02 | Version: v0.10.3
+Last updated: 2026-04-06 | Version: v0.11.0
 
 ## Summary
 
 | 域 | P0 | P1 | P2 | 整体状态 |
 |----|----|----|----|---------|
-| graph | 0 | 0 | 1 | 🟡 P2 待修 |
+| graph | 0 | 0 | 0 | 🟢 稳定 |
 | algorithms | 0 | 0 | 0 | 🟢 稳定 |
 | vector | 0 | 0 | 0 | 🟢 稳定 |
 | rag | 0 | 0 | 0 | 🟢 稳定 |
 | schema | 0 | 0 | 0 | 🟢 稳定 |
 | export | 0 | 0 | 0 | 🟢 稳定 |
+| async_kg | 0 | 0 | 0 | 🟢 稳定（新增 v0.11.0） |
 
 ## P0 — 全部已修复 ✅
 
@@ -46,9 +47,11 @@ Last updated: 2026-04-02 | Version: v0.10.3
 
 所有 P0/P1/P2 问题已全部修复。下一步可考虑：
 - RAG `SubprocessEmbedder` 集成测试（需外部 Python 服务）
+- `AsyncKnowledgeGraph` 并发读写压力测试（多实例 WAL 模式）
 
 ## 已完成优化
 
 - **持久化 TurboQuant 索引** ✅（v0.10.2）：索引序列化存入 `kg_turboquant_cache` 表，以向量数量为版本号，同一 DB 多次 RAG 查询只建一次索引
 - **Schema 自动迁移** ✅（v0.10.3）：`kg_schema_version` 表 + `ensure_schema()` 迁移运行器，支持增量升级（含旧 DB 探测）；`create_schema()` 保持向后兼容
 - **缓存失效策略升级** ✅（v0.10.3）：`kg_turboquant_cache` 新增 `vectors_checksum`（`SUM(entity_id)`），count + checksum 双重校验，防止同等数量但不同向量集导致的缓存误判
+- **Async API** ✅（v0.11.0）：`AsyncKnowledgeGraph`（`Arc<Mutex<KnowledgeGraph>>`）+ `AsyncEmbeddingGenerator`，feature-gated，122 单元测试 + 11 异步集成测试全通过

--- a/examples/async_demo.rs
+++ b/examples/async_demo.rs
@@ -1,0 +1,178 @@
+//! Async API demo: concurrent knowledge graph pipeline
+//!
+//! Simulates a research paper ingestion pipeline that:
+//! 1. Concurrently inserts 20 papers + 5 skills
+//! 2. Builds citation relations
+//! 3. Stores synthetic vector embeddings
+//! 4. Runs graph analytics (PageRank, Louvain)
+//! 5. Performs semantic search
+//! 6. Shows shortest path between two papers
+//!
+//! Run with:
+//!   cargo run --example async_demo --features async
+
+#![cfg(feature = "async")]
+
+use std::sync::Arc;
+
+use sqlite_knowledge_graph::{AsyncKnowledgeGraph, Direction, Entity, PageRankConfig, Relation};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Async Knowledge Graph Demo ===\n");
+
+    let kg = Arc::new(AsyncKnowledgeGraph::open_in_memory_sync()?);
+
+    // ── Step 1: Concurrent paper insertion ───────────────────────────────────
+    println!("[1] Inserting 20 papers concurrently...");
+
+    let paper_titles = vec![
+        "Attention Is All You Need",
+        "BERT: Pre-training of Deep Bidirectional Transformers",
+        "GPT-3: Language Models are Few-Shot Learners",
+        "ResNet: Deep Residual Learning for Image Recognition",
+        "Word2Vec: Distributed Representations of Words",
+        "GAN: Generative Adversarial Networks",
+        "Transformer-XL: Attentive Language Models Beyond a Fixed-Length Context",
+        "ELMo: Deep Contextualized Word Representations",
+        "XLNet: Generalized Autoregressive Pretraining",
+        "RoBERTa: A Robustly Optimized BERT Pretraining Approach",
+        "ALBERT: A Lite BERT for Self-supervised Learning",
+        "DistilBERT: a distilled version of BERT",
+        "T5: Exploring the Limits of Transfer Learning",
+        "BART: Denoising Sequence-to-Sequence Pre-training",
+        "DeBERTa: Decoding-enhanced BERT with Disentangled Attention",
+        "LLaMA: Open and Efficient Foundation Language Models",
+        "Chinchilla: Training Compute-Optimal Large Language Models",
+        "PaLM: Scaling Language Modeling with Pathways",
+        "InstructGPT: Training language models to follow instructions",
+        "RLHF: Learning to summarize from human feedback",
+    ];
+
+    let handles: Vec<_> = paper_titles
+        .iter()
+        .enumerate()
+        .map(|(i, title)| {
+            let kg = Arc::clone(&kg);
+            let mut entity = Entity::new("paper", *title);
+            entity.set_property("year", serde_json::json!(2017 + (i / 3) as i64));
+            entity.set_property("citations", serde_json::json!(1000 - i as i64 * 40));
+            tokio::spawn(async move { kg.insert_entity(entity).await })
+        })
+        .collect();
+
+    let mut paper_ids = Vec::new();
+    for h in handles {
+        paper_ids.push(h.await??);
+    }
+    println!("    ✓ {} papers inserted", paper_ids.len());
+
+    // ── Step 2: Insert skills sequentially ───────────────────────────────────
+    println!("[2] Inserting skills...");
+    let skills = ["NLP", "Computer Vision", "Reinforcement Learning", "Graph ML", "Generative AI"];
+    let mut skill_ids = Vec::new();
+    for skill in &skills {
+        let id = kg.insert_entity(Entity::new("skill", *skill)).await?;
+        skill_ids.push(id);
+    }
+    println!("    ✓ {} skills inserted", skill_ids.len());
+
+    // ── Step 3: Build citation graph ─────────────────────────────────────────
+    println!("[3] Building citation relations...");
+    let citation_pairs = vec![
+        (0, 1), (0, 4), (1, 4), (1, 5), (2, 0), (2, 1), (3, 4),
+        (6, 0), (7, 1), (8, 0), (8, 1), (9, 1), (10, 1), (11, 1),
+        (12, 0), (12, 1), (13, 0), (14, 1), (15, 0), (16, 0),
+    ];
+
+    for (from, to) in &citation_pairs {
+        let rel = Relation::new(paper_ids[*from], paper_ids[*to], "cites", 0.9)?;
+        kg.insert_relation(rel).await?;
+    }
+
+    // Link papers to skills
+    let paper_skill_map = vec![(0, 0), (1, 0), (2, 0), (3, 1), (4, 0), (15, 4), (19, 2)];
+    for (paper_idx, skill_idx) in &paper_skill_map {
+        let rel = Relation::new(paper_ids[*paper_idx], skill_ids[*skill_idx], "uses_skill", 0.8)?;
+        kg.insert_relation(rel).await?;
+    }
+    println!("    ✓ {} citation + {} skill relations", citation_pairs.len(), paper_skill_map.len());
+
+    // ── Step 4: Store synthetic embeddings ───────────────────────────────────
+    println!("[4] Storing synthetic 8-dim embeddings...");
+    for (i, &id) in paper_ids.iter().enumerate() {
+        // Synthetic embedding: papers in same "era" cluster together
+        let era = (i / 5) as f32;
+        let vec: Vec<f32> = (0..8)
+            .map(|d| if d == (i % 8) { 1.0 } else { era * 0.1 })
+            .collect();
+        kg.insert_vector(id, vec).await?;
+    }
+    println!("    ✓ {} embeddings stored", paper_ids.len());
+
+    // ── Step 5: Graph analytics ───────────────────────────────────────────────
+    println!("[5] Running PageRank...");
+    let pr_config = PageRankConfig {
+        damping: 0.85,
+        max_iterations: 100,
+        tolerance: 1e-6,
+    };
+    let scores = kg.kg_pagerank(Some(pr_config)).await?;
+    println!("    Top 5 by PageRank:");
+    for (entity_id, score) in scores.iter().take(5) {
+        let entity = kg.get_entity(*entity_id).await?;
+        println!("      [{:.4}] {}", score, entity.name);
+    }
+
+    println!("[5b] Running Louvain community detection...");
+    let communities = kg.kg_louvain().await?;
+    println!("    {} communities detected, modularity = {:.4}", communities.num_communities, communities.modularity);
+
+    // ── Step 6: Semantic search ───────────────────────────────────────────────
+    println!("[6] Semantic search (query similar to paper index 0)...");
+    let query_vec: Vec<f32> = (0..8).map(|d| if d == 0 { 1.0 } else { 0.0 }).collect();
+    let results = kg.kg_semantic_search(query_vec, 3).await?;
+    println!("    Top 3 semantic matches:");
+    for r in &results {
+        println!("      [{:.3}] {}", r.similarity, r.entity.name);
+    }
+
+    // ── Step 7: Graph traversal ───────────────────────────────────────────────
+    println!("[7] BFS from '{}' (depth 2)...", paper_titles[2]);
+    let bfs_nodes = kg.kg_bfs_traversal(paper_ids[2], Direction::Outgoing, 2).await?;
+    println!("    {} nodes reachable:", bfs_nodes.len());
+    for node in bfs_nodes.iter().take(5) {
+        let e = kg.get_entity(node.entity_id).await?;
+        println!("      depth={} | {}", node.depth, e.name);
+    }
+
+    // ── Step 8: Shortest path ─────────────────────────────────────────────────
+    println!("[8] Shortest path: '{}' → '{}'", paper_titles[2], paper_titles[4]);
+    match kg.kg_shortest_path(paper_ids[2], paper_ids[4], 5).await? {
+        Some(path) => {
+            println!("    Found path ({} hops, total weight = {:.2}):", path.steps.len(), path.total_weight);
+            for step in &path.steps {
+                let from = kg.get_entity(step.from_id).await?;
+                let to = kg.get_entity(step.to_id).await?;
+                println!("      {} --[{}]--> {}", from.name, step.relation_type, to.name);
+            }
+        }
+        None => println!("    No path found within depth 5"),
+    }
+
+    // ── Step 9: Graph stats ───────────────────────────────────────────────────
+    println!("[9] Graph statistics:");
+    let stats = kg.kg_graph_stats().await?;
+    println!("    Entities : {}", stats.total_entities);
+    println!("    Relations: {}", stats.total_relations);
+    println!("    Avg degree: {:.2}", stats.avg_degree);
+    println!("    Density   : {:.4}", stats.density);
+
+    println!("\n=== Demo complete ===");
+    Ok(())
+}
+
+#[cfg(not(feature = "async"))]
+fn main() {
+    eprintln!("Run with: cargo run --example async_demo --features async");
+}

--- a/examples/async_demo.rs
+++ b/examples/async_demo.rs
@@ -11,8 +11,6 @@
 //! Run with:
 //!   cargo run --example async_demo --features async
 
-#![cfg(feature = "async")]
-
 use std::sync::Arc;
 
 use sqlite_knowledge_graph::{AsyncKnowledgeGraph, Direction, Entity, PageRankConfig, Relation};
@@ -69,7 +67,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Step 2: Insert skills sequentially ───────────────────────────────────
     println!("[2] Inserting skills...");
-    let skills = ["NLP", "Computer Vision", "Reinforcement Learning", "Graph ML", "Generative AI"];
+    let skills = [
+        "NLP",
+        "Computer Vision",
+        "Reinforcement Learning",
+        "Graph ML",
+        "Generative AI",
+    ];
     let mut skill_ids = Vec::new();
     for skill in &skills {
         let id = kg.insert_entity(Entity::new("skill", *skill)).await?;
@@ -80,9 +84,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 3: Build citation graph ─────────────────────────────────────────
     println!("[3] Building citation relations...");
     let citation_pairs = vec![
-        (0, 1), (0, 4), (1, 4), (1, 5), (2, 0), (2, 1), (3, 4),
-        (6, 0), (7, 1), (8, 0), (8, 1), (9, 1), (10, 1), (11, 1),
-        (12, 0), (12, 1), (13, 0), (14, 1), (15, 0), (16, 0),
+        (0, 1),
+        (0, 4),
+        (1, 4),
+        (1, 5),
+        (2, 0),
+        (2, 1),
+        (3, 4),
+        (6, 0),
+        (7, 1),
+        (8, 0),
+        (8, 1),
+        (9, 1),
+        (10, 1),
+        (11, 1),
+        (12, 0),
+        (12, 1),
+        (13, 0),
+        (14, 1),
+        (15, 0),
+        (16, 0),
     ];
 
     for (from, to) in &citation_pairs {
@@ -93,10 +114,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Link papers to skills
     let paper_skill_map = vec![(0, 0), (1, 0), (2, 0), (3, 1), (4, 0), (15, 4), (19, 2)];
     for (paper_idx, skill_idx) in &paper_skill_map {
-        let rel = Relation::new(paper_ids[*paper_idx], skill_ids[*skill_idx], "uses_skill", 0.8)?;
+        let rel = Relation::new(
+            paper_ids[*paper_idx],
+            skill_ids[*skill_idx],
+            "uses_skill",
+            0.8,
+        )?;
         kg.insert_relation(rel).await?;
     }
-    println!("    ✓ {} citation + {} skill relations", citation_pairs.len(), paper_skill_map.len());
+    println!(
+        "    ✓ {} citation + {} skill relations",
+        citation_pairs.len(),
+        paper_skill_map.len()
+    );
 
     // ── Step 4: Store synthetic embeddings ───────────────────────────────────
     println!("[4] Storing synthetic 8-dim embeddings...");
@@ -126,7 +156,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("[5b] Running Louvain community detection...");
     let communities = kg.kg_louvain().await?;
-    println!("    {} communities detected, modularity = {:.4}", communities.num_communities, communities.modularity);
+    println!(
+        "    {} communities detected, modularity = {:.4}",
+        communities.num_communities, communities.modularity
+    );
 
     // ── Step 6: Semantic search ───────────────────────────────────────────────
     println!("[6] Semantic search (query similar to paper index 0)...");
@@ -139,7 +172,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Step 7: Graph traversal ───────────────────────────────────────────────
     println!("[7] BFS from '{}' (depth 2)...", paper_titles[2]);
-    let bfs_nodes = kg.kg_bfs_traversal(paper_ids[2], Direction::Outgoing, 2).await?;
+    let bfs_nodes = kg
+        .kg_bfs_traversal(paper_ids[2], Direction::Outgoing, 2)
+        .await?;
     println!("    {} nodes reachable:", bfs_nodes.len());
     for node in bfs_nodes.iter().take(5) {
         let e = kg.get_entity(node.entity_id).await?;
@@ -147,14 +182,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // ── Step 8: Shortest path ─────────────────────────────────────────────────
-    println!("[8] Shortest path: '{}' → '{}'", paper_titles[2], paper_titles[4]);
+    println!(
+        "[8] Shortest path: '{}' → '{}'",
+        paper_titles[2], paper_titles[4]
+    );
     match kg.kg_shortest_path(paper_ids[2], paper_ids[4], 5).await? {
         Some(path) => {
-            println!("    Found path ({} hops, total weight = {:.2}):", path.steps.len(), path.total_weight);
+            println!(
+                "    Found path ({} hops, total weight = {:.2}):",
+                path.steps.len(),
+                path.total_weight
+            );
             for step in &path.steps {
                 let from = kg.get_entity(step.from_id).await?;
                 let to = kg.get_entity(step.to_id).await?;
-                println!("      {} --[{}]--> {}", from.name, step.relation_type, to.name);
+                println!(
+                    "      {} --[{}]--> {}",
+                    from.name, step.relation_type, to.name
+                );
             }
         }
         None => println!("    No path found within depth 5"),
@@ -170,9 +215,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\n=== Demo complete ===");
     Ok(())
-}
-
-#[cfg(not(feature = "async"))]
-fn main() {
-    eprintln!("Run with: cargo run --example async_demo --features async");
 }

--- a/src/async_kg/embed.rs
+++ b/src/async_kg/embed.rs
@@ -110,11 +110,30 @@ impl AsyncEmbeddingGenerator {
 
         let total_count = entities.len() as i64;
 
-        // Filter to those that need embeddings
-        let to_process: Vec<_> = if self.skip_existing {
-            // Entities that have no stored vector yet (checked by attempting
-            // search; we use a heuristic — filter by id in a blocking call)
-            entities
+        // Filter to those that need embeddings (skip entities that already have
+        // a non-zero vector stored).
+        let to_process = if self.skip_existing {
+            let mut need_embedding = Vec::new();
+            for entity in entities {
+                if let Some(id) = entity.id {
+                    let has_vector = kg.search_vectors(vec![0.0; 1], 1).await;
+                    // If get_vector fails or returns empty, the entity needs embedding.
+                    // We use a lightweight check via the inner KnowledgeGraph.
+                    let inner = kg.inner();
+                    let skip = {
+                        let kg_lock = inner.lock().map_err(|e| {
+                            crate::error::Error::TaskPanicked(format!("mutex poisoned: {e}"))
+                        })?;
+                        let store = crate::vector::VectorStore::new();
+                        store.get_vector(kg_lock.connection(), id).is_ok()
+                    };
+                    drop(has_vector);
+                    if !skip {
+                        need_embedding.push(entity);
+                    }
+                }
+            }
+            need_embedding
         } else {
             entities
         };
@@ -128,10 +147,7 @@ impl AsyncEmbeddingGenerator {
             });
         }
 
-        let texts: Vec<String> = to_process
-            .iter()
-            .map(|e| e.name.clone())
-            .collect();
+        let texts: Vec<String> = to_process.iter().map(|e| e.name.clone()).collect();
 
         let embeddings = self.generate_embeddings(texts).await?;
 

--- a/src/async_kg/embed.rs
+++ b/src/async_kg/embed.rs
@@ -1,0 +1,229 @@
+//! Async embedding generation using `tokio::process::Command`.
+//!
+//! This module mirrors [`crate::embed::EmbeddingGenerator`] but uses the
+//! Tokio async process API instead of `std::process::Command`.  The Python
+//! subprocess for sentence-transformers can take 2–10 s per batch, so driving
+//! it through Tokio's I/O reactor is significantly more efficient than
+//! occupying a blocking thread pool slot.
+
+use std::io;
+
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use crate::embed::{EmbeddingConfig, EmbeddingStats};
+use crate::error::{Error, Result};
+
+/// Async counterpart to [`crate::embed::EmbeddingGenerator`].
+///
+/// Uses `tokio::process::Command` so the Python subprocess does not block a
+/// Tokio worker thread while waiting for embeddings to be computed.
+pub struct AsyncEmbeddingGenerator {
+    config: EmbeddingConfig,
+    /// If `true`, skip entities that already have non-zero embeddings.
+    pub skip_existing: bool,
+}
+
+impl AsyncEmbeddingGenerator {
+    /// Create a new generator with default configuration.
+    pub fn new() -> Self {
+        Self {
+            config: EmbeddingConfig::default(),
+            skip_existing: true,
+        }
+    }
+
+    /// Create a new generator with a custom configuration.
+    pub fn with_config(config: EmbeddingConfig) -> Self {
+        Self {
+            config,
+            skip_existing: true,
+        }
+    }
+
+    /// If `force` is `true`, regenerate embeddings even for entities that
+    /// already have non-zero vectors.
+    pub fn with_force(mut self, force: bool) -> Self {
+        self.skip_existing = !force;
+        self
+    }
+
+    /// Generate embeddings for a list of texts using a Python subprocess.
+    ///
+    /// Uses `tokio::process::Command` to drive the subprocess I/O through the
+    /// async runtime's I/O reactor (epoll/kqueue), avoiding blocking thread
+    /// pool occupation for the duration of the Python call.
+    pub async fn generate_embeddings(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let python_script = self.build_python_script();
+
+        let texts_json = serde_json::to_string(&texts)
+            .map_err(|e| Error::Other(format!("failed to serialize texts: {e}")))?;
+
+        let mut child = Command::new("python3")
+            .arg("-c")
+            .arg(&python_script)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| Error::Other(format!("failed to spawn Python: {e}")))?;
+
+        // Write input asynchronously
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(texts_json.as_bytes())
+                .await
+                .map_err(|e| Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, e)))?;
+            // Drop stdin to signal EOF to Python
+        }
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| Error::Other(format!("failed to read Python output: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Other(format!("Python script failed: {stderr}")));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        self.parse_embeddings(&stdout)
+    }
+
+    /// Generate embeddings for all entities of a specific type and store them.
+    ///
+    /// `entity_type` — the `entity_type` column value to filter on (e.g.
+    /// `"paper"` or `"skill"`).
+    pub async fn generate_for_type(
+        &self,
+        kg: &super::AsyncKnowledgeGraph,
+        entity_type: &str,
+    ) -> Result<EmbeddingStats> {
+        let entities = kg
+            .list_entities(Some(entity_type.to_string()), None)
+            .await?;
+
+        let total_count = entities.len() as i64;
+
+        // Filter to those that need embeddings
+        let to_process: Vec<_> = if self.skip_existing {
+            // Entities that have no stored vector yet (checked by attempting
+            // search; we use a heuristic — filter by id in a blocking call)
+            entities
+        } else {
+            entities
+        };
+
+        if to_process.is_empty() {
+            return Ok(EmbeddingStats {
+                total_count,
+                processed_count: 0,
+                skipped_count: total_count,
+                dimension: self.config.dimension,
+            });
+        }
+
+        let texts: Vec<String> = to_process
+            .iter()
+            .map(|e| e.name.clone())
+            .collect();
+
+        let embeddings = self.generate_embeddings(texts).await?;
+
+        let mut processed_count = 0i64;
+        for (entity, embedding) in to_process.iter().zip(embeddings.iter()) {
+            if let Some(id) = entity.id {
+                kg.insert_vector(id, embedding.clone()).await?;
+                processed_count += 1;
+            }
+        }
+
+        Ok(EmbeddingStats {
+            total_count,
+            processed_count,
+            skipped_count: total_count - processed_count,
+            dimension: self.config.dimension,
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    fn build_python_script(&self) -> String {
+        format!(
+            r#"
+import sys
+import json
+
+try:
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer('{model}')
+    texts_json = sys.stdin.read()
+    texts = json.loads(texts_json)
+    embeddings = model.encode(texts, convert_to_numpy=True)
+    print(json.dumps(embeddings.tolist()))
+
+except ImportError:
+    print('{{"error": "sentence-transformers not installed. Run: pip install sentence-transformers"}}', file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f'{{"error": "{{}}"}}".format(str(e)), file=sys.stderr)
+    sys.exit(1)
+"#,
+            model = self.config.model_name
+        )
+    }
+
+    fn parse_embeddings(&self, output: &str) -> Result<Vec<Vec<f32>>> {
+        let embeddings: Vec<Vec<f32>> = serde_json::from_str(output.trim())
+            .map_err(|e| Error::Other(format!("failed to parse embeddings: {e}")))?;
+
+        for embedding in &embeddings {
+            if embedding.len() != self.config.dimension {
+                return Err(Error::InvalidVectorDimension {
+                    expected: self.config.dimension,
+                    actual: embedding.len(),
+                });
+            }
+        }
+
+        Ok(embeddings)
+    }
+}
+
+impl Default for AsyncEmbeddingGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let gen = AsyncEmbeddingGenerator::new();
+        assert_eq!(gen.config.model_name, "all-MiniLM-L6-v2");
+        assert_eq!(gen.config.dimension, 384);
+        assert!(gen.skip_existing);
+    }
+
+    #[test]
+    fn test_with_force() {
+        let gen = AsyncEmbeddingGenerator::new().with_force(true);
+        assert!(!gen.skip_existing);
+    }
+
+    #[tokio::test]
+    async fn test_empty_texts_returns_empty() {
+        let gen = AsyncEmbeddingGenerator::new();
+        let result = gen.generate_embeddings(vec![]).await.unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/src/async_kg/mod.rs
+++ b/src/async_kg/mod.rs
@@ -257,7 +257,13 @@ impl AsyncKnowledgeGraph {
         min_arity: Option<usize>,
         max_arity: Option<usize>,
     ) -> Result<Vec<HigherOrderNeighbor>> {
-        dispatch!(self, get_higher_order_neighbors, entity_id, min_arity, max_arity)
+        dispatch!(
+            self,
+            get_higher_order_neighbors,
+            entity_id,
+            min_arity,
+            max_arity
+        )
     }
 
     /// Get all hyperedges an entity participates in.
@@ -367,10 +373,7 @@ impl AsyncKnowledgeGraph {
     // ── Graph algorithms ──────────────────────────────────────────────────
 
     /// PageRank scores for all entities, sorted descending.
-    pub async fn kg_pagerank(
-        &self,
-        config: Option<PageRankConfig>,
-    ) -> Result<Vec<(i64, f64)>> {
+    pub async fn kg_pagerank(&self, config: Option<PageRankConfig>) -> Result<Vec<(i64, f64)>> {
         dispatch!(self, kg_pagerank, config)
     }
 
@@ -401,6 +404,27 @@ impl AsyncKnowledgeGraph {
         dispatch!(self, kg_higher_order_bfs, start_id, max_depth, min_arity)
     }
 
+    /// Hyperedge degree centrality for an entity.
+    pub async fn kg_hyperedge_degree(&self, entity_id: i64) -> Result<f64> {
+        dispatch!(self, kg_hyperedge_degree, entity_id)
+    }
+
+    /// Entity-level hypergraph PageRank using Zhou formula.
+    pub async fn kg_hypergraph_entity_pagerank(
+        &self,
+        damping: Option<f64>,
+        max_iter: Option<usize>,
+        tolerance: Option<f64>,
+    ) -> Result<std::collections::HashMap<i64, f64>> {
+        dispatch!(
+            self,
+            kg_hypergraph_entity_pagerank,
+            damping,
+            max_iter,
+            tolerance
+        )
+    }
+
     /// Shortest path through hyperedges between two entities.
     pub async fn kg_higher_order_shortest_path(
         &self,
@@ -408,7 +432,13 @@ impl AsyncKnowledgeGraph {
         to_id: i64,
         max_depth: u32,
     ) -> Result<Option<HigherOrderPath>> {
-        dispatch!(self, kg_higher_order_shortest_path, from_id, to_id, max_depth)
+        dispatch!(
+            self,
+            kg_higher_order_shortest_path,
+            from_id,
+            to_id,
+            max_depth
+        )
     }
 
     // ── Export ────────────────────────────────────────────────────────────

--- a/src/async_kg/mod.rs
+++ b/src/async_kg/mod.rs
@@ -1,0 +1,506 @@
+//! Async wrapper around [`KnowledgeGraph`].
+//!
+//! Enabled with the `async` Cargo feature. All blocking SQLite operations are
+//! dispatched to a `tokio::task::spawn_blocking` thread, keeping the async
+//! executor thread free.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use sqlite_knowledge_graph::{AsyncKnowledgeGraph, Entity};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let kg = AsyncKnowledgeGraph::open_in_memory_sync()?;
+//!     let entity = Entity::new("paper", "Async Test");
+//!     let id = kg.insert_entity(entity).await?;
+//!     let retrieved = kg.get_entity(id).await?;
+//!     println!("{:?}", retrieved);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Thread Safety
+//!
+//! Internally the [`KnowledgeGraph`] is wrapped in `Arc<Mutex<_>>`. All async
+//! methods acquire the lock inside the `spawn_blocking` closure — the lock is
+//! released before any `.await` point, so no `MutexGuard` ever crosses an
+//! await boundary.
+//!
+//! For read-heavy concurrent workloads, consider opening multiple
+//! `AsyncKnowledgeGraph` instances on the same file — SQLite WAL mode supports
+//! concurrent readers.
+
+pub mod embed;
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::algorithms::GraphAnalysis;
+use crate::error::{Error, Result};
+use crate::{
+    CommunityResult, Direction, DotConfig, GraphContext, GraphStats, HigherOrderNeighbor,
+    HigherOrderPath, HybridSearchResult, Hyperedge, KnowledgeGraph, Neighbor, PageRankConfig,
+    SearchResult, SearchResultWithEntity, TraversalNode, TraversalPath,
+};
+use crate::{D3ExportGraph, Entity, Relation};
+
+/// Async wrapper around [`KnowledgeGraph`].
+///
+/// Every method dispatches the blocking SQLite work to a dedicated OS thread
+/// via [`tokio::task::spawn_blocking`], leaving the async executor responsive.
+///
+/// # Note on argument ownership
+///
+/// Unlike the sync [`KnowledgeGraph`] which borrows (`&Entity`), the async
+/// methods take **owned** values. This is required because the closure passed
+/// to `spawn_blocking` must be `'static`.
+pub struct AsyncKnowledgeGraph {
+    inner: Arc<Mutex<KnowledgeGraph>>,
+}
+
+// The Arc<Mutex<KnowledgeGraph>> can be sent across threads safely.
+// KnowledgeGraph itself is not Send (rusqlite::Connection), but the Mutex
+// wrapper ensures exclusive access.
+unsafe impl Send for AsyncKnowledgeGraph {}
+unsafe impl Sync for AsyncKnowledgeGraph {}
+
+/// Dispatch a method call to a `spawn_blocking` thread.
+///
+/// Clones the `Arc`, moves it into the closure, locks the `Mutex` inside the
+/// closure (on the blocking thread), calls the method, and awaits the result.
+macro_rules! dispatch {
+    ($self:expr, $method:ident $(, $arg:expr)*) => {{
+        let inner = Arc::clone(&$self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.$method($($arg),*)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }};
+}
+
+impl AsyncKnowledgeGraph {
+    // ── Construction ──────────────────────────────────────────────────────
+
+    /// Open an async knowledge graph backed by a file on disk.
+    ///
+    /// This call blocks briefly (opens the SQLite connection) but is typically
+    /// called once at startup so the blocking cost is acceptable.
+    pub fn open_sync<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let kg = KnowledgeGraph::open(path)?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(kg)),
+        })
+    }
+
+    /// Open an in-memory async knowledge graph (useful for testing).
+    pub fn open_in_memory_sync() -> Result<Self> {
+        let kg = KnowledgeGraph::open_in_memory()?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(kg)),
+        })
+    }
+
+    /// Wrap an existing synchronous [`KnowledgeGraph`] in an async adapter.
+    pub fn from_sync(kg: KnowledgeGraph) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(kg)),
+        }
+    }
+
+    /// Return a clone of the inner `Arc<Mutex<KnowledgeGraph>>` for operations
+    /// not yet exposed through the async API.
+    pub fn inner(&self) -> Arc<Mutex<KnowledgeGraph>> {
+        Arc::clone(&self.inner)
+    }
+
+    // ── Entity CRUD ───────────────────────────────────────────────────────
+
+    /// Insert an entity and return its new ID.
+    pub async fn insert_entity(&self, entity: Entity) -> Result<i64> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.insert_entity(&entity)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Get an entity by ID.
+    pub async fn get_entity(&self, id: i64) -> Result<Entity> {
+        dispatch!(self, get_entity, id)
+    }
+
+    /// List entities with optional type filter and limit.
+    pub async fn list_entities(
+        &self,
+        entity_type: Option<String>,
+        limit: Option<i64>,
+    ) -> Result<Vec<Entity>> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.list_entities(entity_type.as_deref(), limit)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Update an entity.
+    pub async fn update_entity(&self, entity: Entity) -> Result<()> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.update_entity(&entity)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Delete an entity by ID.
+    pub async fn delete_entity(&self, id: i64) -> Result<()> {
+        dispatch!(self, delete_entity, id)
+    }
+
+    // ── Relation CRUD ─────────────────────────────────────────────────────
+
+    /// Insert a relation between two entities and return its new ID.
+    pub async fn insert_relation(&self, relation: Relation) -> Result<i64> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.insert_relation(&relation)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Get neighbours of an entity up to `depth` hops.
+    pub async fn get_neighbors(&self, entity_id: i64, depth: u32) -> Result<Vec<Neighbor>> {
+        dispatch!(self, get_neighbors, entity_id, depth)
+    }
+
+    // ── Hyperedge CRUD ────────────────────────────────────────────────────
+
+    /// Insert a hyperedge and return its new ID.
+    pub async fn insert_hyperedge(&self, hyperedge: Hyperedge) -> Result<i64> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.insert_hyperedge(&hyperedge)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Get a hyperedge by ID.
+    pub async fn get_hyperedge(&self, id: i64) -> Result<Hyperedge> {
+        dispatch!(self, get_hyperedge, id)
+    }
+
+    /// List hyperedges with optional filters.
+    pub async fn list_hyperedges(
+        &self,
+        hyperedge_type: Option<String>,
+        min_arity: Option<usize>,
+        max_arity: Option<usize>,
+        limit: Option<i64>,
+    ) -> Result<Vec<Hyperedge>> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.list_hyperedges(hyperedge_type.as_deref(), min_arity, max_arity, limit)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Update a hyperedge.
+    pub async fn update_hyperedge(&self, hyperedge: Hyperedge) -> Result<()> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.update_hyperedge(&hyperedge)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Delete a hyperedge by ID.
+    pub async fn delete_hyperedge(&self, id: i64) -> Result<()> {
+        dispatch!(self, delete_hyperedge, id)
+    }
+
+    /// Get higher-order neighbours connected through hyperedges.
+    pub async fn get_higher_order_neighbors(
+        &self,
+        entity_id: i64,
+        min_arity: Option<usize>,
+        max_arity: Option<usize>,
+    ) -> Result<Vec<HigherOrderNeighbor>> {
+        dispatch!(self, get_higher_order_neighbors, entity_id, min_arity, max_arity)
+    }
+
+    /// Get all hyperedges an entity participates in.
+    pub async fn get_entity_hyperedges(&self, entity_id: i64) -> Result<Vec<Hyperedge>> {
+        dispatch!(self, get_entity_hyperedges, entity_id)
+    }
+
+    // ── Vector search ─────────────────────────────────────────────────────
+
+    /// Store a vector embedding for an entity.
+    pub async fn insert_vector(&self, entity_id: i64, vector: Vec<f32>) -> Result<()> {
+        dispatch!(self, insert_vector, entity_id, vector)
+    }
+
+    /// Exact nearest-neighbour search over stored vectors.
+    pub async fn search_vectors(&self, query: Vec<f32>, k: usize) -> Result<Vec<SearchResult>> {
+        dispatch!(self, search_vectors, query, k)
+    }
+
+    /// Semantic search — returns top-k entities by vector similarity.
+    pub async fn kg_semantic_search(
+        &self,
+        query_embedding: Vec<f32>,
+        k: usize,
+    ) -> Result<Vec<SearchResultWithEntity>> {
+        dispatch!(self, kg_semantic_search, query_embedding, k)
+    }
+
+    /// Hybrid search combining semantic and graph context.
+    pub async fn kg_hybrid_search(
+        &self,
+        query_text: String,
+        query_embedding: Vec<f32>,
+        k: usize,
+    ) -> Result<Vec<HybridSearchResult>> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.kg_hybrid_search(&query_text, query_embedding, k)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+
+    /// Find entities similar to the given entity by vector cosine similarity.
+    pub async fn kg_similar_entities(
+        &self,
+        entity_id: i64,
+        k: usize,
+    ) -> Result<Vec<SearchResultWithEntity>> {
+        dispatch!(self, kg_similar_entities, entity_id, k)
+    }
+
+    /// Get graph context (root + depth-1 neighbours) for an entity.
+    pub async fn kg_get_context(&self, entity_id: i64, depth: u32) -> Result<GraphContext> {
+        dispatch!(self, kg_get_context, entity_id, depth)
+    }
+
+    /// Find related entities above a relation-weight threshold.
+    pub async fn kg_find_related(
+        &self,
+        entity_id: i64,
+        threshold: f64,
+    ) -> Result<Vec<(Entity, f64)>> {
+        dispatch!(self, kg_find_related, entity_id, threshold)
+    }
+
+    // ── Graph traversal ───────────────────────────────────────────────────
+
+    /// BFS traversal from `start_id` up to `max_depth` hops.
+    pub async fn kg_bfs_traversal(
+        &self,
+        start_id: i64,
+        direction: Direction,
+        max_depth: u32,
+    ) -> Result<Vec<TraversalNode>> {
+        dispatch!(self, kg_bfs_traversal, start_id, direction, max_depth)
+    }
+
+    /// DFS traversal from `start_id` up to `max_depth` hops.
+    pub async fn kg_dfs_traversal(
+        &self,
+        start_id: i64,
+        direction: Direction,
+        max_depth: u32,
+    ) -> Result<Vec<TraversalNode>> {
+        dispatch!(self, kg_dfs_traversal, start_id, direction, max_depth)
+    }
+
+    /// Shortest path (BFS) between two entities.
+    pub async fn kg_shortest_path(
+        &self,
+        from_id: i64,
+        to_id: i64,
+        max_depth: u32,
+    ) -> Result<Option<TraversalPath>> {
+        dispatch!(self, kg_shortest_path, from_id, to_id, max_depth)
+    }
+
+    /// Graph statistics (entity count, relation count, density, etc.).
+    pub async fn kg_graph_stats(&self) -> Result<GraphStats> {
+        dispatch!(self, kg_graph_stats)
+    }
+
+    // ── Graph algorithms ──────────────────────────────────────────────────
+
+    /// PageRank scores for all entities, sorted descending.
+    pub async fn kg_pagerank(
+        &self,
+        config: Option<PageRankConfig>,
+    ) -> Result<Vec<(i64, f64)>> {
+        dispatch!(self, kg_pagerank, config)
+    }
+
+    /// Louvain community detection.
+    pub async fn kg_louvain(&self) -> Result<CommunityResult> {
+        dispatch!(self, kg_louvain)
+    }
+
+    /// Connected components — list of entity-ID groups.
+    pub async fn kg_connected_components(&self) -> Result<Vec<Vec<i64>>> {
+        dispatch!(self, kg_connected_components)
+    }
+
+    /// Full graph analysis: PageRank + Louvain + connected components.
+    pub async fn kg_analyze(&self) -> Result<GraphAnalysis> {
+        dispatch!(self, kg_analyze)
+    }
+
+    // ── Higher-order traversal ────────────────────────────────────────────
+
+    /// BFS through hyperedges from `start_id`.
+    pub async fn kg_higher_order_bfs(
+        &self,
+        start_id: i64,
+        max_depth: u32,
+        min_arity: Option<usize>,
+    ) -> Result<Vec<TraversalNode>> {
+        dispatch!(self, kg_higher_order_bfs, start_id, max_depth, min_arity)
+    }
+
+    /// Shortest path through hyperedges between two entities.
+    pub async fn kg_higher_order_shortest_path(
+        &self,
+        from_id: i64,
+        to_id: i64,
+        max_depth: u32,
+    ) -> Result<Option<HigherOrderPath>> {
+        dispatch!(self, kg_higher_order_shortest_path, from_id, to_id, max_depth)
+    }
+
+    // ── Export ────────────────────────────────────────────────────────────
+
+    /// Export graph as D3.js JSON.
+    pub async fn export_json(&self) -> Result<D3ExportGraph> {
+        dispatch!(self, export_json)
+    }
+
+    /// Export graph as DOT (Graphviz) string.
+    pub async fn export_dot(&self, config: DotConfig) -> Result<String> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let kg = inner
+                .lock()
+                .map_err(|e| Error::TaskPanicked(format!("mutex poisoned: {e}")))?;
+            kg.export_dot(&config)
+        })
+        .await
+        .map_err(|e| Error::TaskPanicked(e.to_string()))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Entity;
+
+    #[tokio::test]
+    async fn test_open_in_memory() {
+        let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+        // Verify we can access the inner KnowledgeGraph
+        let _inner = kg.inner();
+    }
+
+    #[tokio::test]
+    async fn test_crud_roundtrip() {
+        let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+        let entity = Entity::new("paper", "Async Test Paper");
+        let id = kg.insert_entity(entity).await.unwrap();
+
+        let retrieved = kg.get_entity(id).await.unwrap();
+        assert_eq!(retrieved.name, "Async Test Paper");
+        assert_eq!(retrieved.entity_type, "paper");
+
+        let list = kg.list_entities(Some("paper".into()), None).await.unwrap();
+        assert_eq!(list.len(), 1);
+
+        let mut updated = retrieved.clone();
+        updated.name = "Updated Async Paper".to_string();
+        kg.update_entity(updated).await.unwrap();
+
+        let after_update = kg.get_entity(id).await.unwrap();
+        assert_eq!(after_update.name, "Updated Async Paper");
+
+        kg.delete_entity(id).await.unwrap();
+        let after_delete = kg.get_entity(id).await;
+        assert!(after_delete.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_insert_relation() {
+        let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+        let id1 = kg.insert_entity(Entity::new("node", "A")).await.unwrap();
+        let id2 = kg.insert_entity(Entity::new("node", "B")).await.unwrap();
+
+        use crate::graph::Relation;
+        let relation = Relation::new(id1, id2, "links_to", 0.9).unwrap();
+        let _rel_id = kg.insert_relation(relation).await.unwrap();
+
+        let neighbors = kg.get_neighbors(id1, 1).await.unwrap();
+        assert_eq!(neighbors.len(), 1);
+        assert_eq!(neighbors[0].entity.id.unwrap(), id2);
+    }
+
+    #[tokio::test]
+    async fn test_from_sync() {
+        let sync_kg = KnowledgeGraph::open_in_memory().unwrap();
+        let async_kg = AsyncKnowledgeGraph::from_sync(sync_kg);
+        let entity = Entity::new("test", "FromSync");
+        let id = async_kg.insert_entity(entity).await.unwrap();
+        assert!(id > 0);
+    }
+
+    #[tokio::test]
+    async fn test_into_async_conversion() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        let async_kg = kg.into_async();
+        let entity = Entity::new("test", "IntoAsync");
+        let id = async_kg.insert_entity(entity).await.unwrap();
+        assert!(id > 0);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,4 +47,7 @@ pub enum Error {
 
     #[error("Other error: {0}")]
     Other(String),
+
+    #[error("background task failed: {0}")]
+    TaskPanicked(String),
 }

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -340,7 +340,7 @@ mod tests {
     fn test_export_dot_max_nodes() {
         let kg = KnowledgeGraph::open_in_memory().unwrap();
         for i in 0..5 {
-            kg.insert_entity(&Entity::new("concept", &format!("Concept {i}")))
+            kg.insert_entity(&Entity::new("concept", format!("Concept {i}")))
                 .unwrap();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,13 @@ pub mod rag;
 pub mod schema;
 pub mod vector;
 
+#[cfg(feature = "async")]
+pub mod async_kg;
+#[cfg(feature = "async")]
+pub use async_kg::AsyncKnowledgeGraph;
+#[cfg(feature = "async")]
+pub use async_kg::embed::AsyncEmbeddingGenerator;
+
 /// Read a weight column that may be stored as REAL, INTEGER, NULL, or 8-byte BLOB.
 ///
 /// Python's sqlite3 module stores numpy.float64 as a little-endian IEEE 754
@@ -621,6 +628,14 @@ impl KnowledgeGraph {
     /// ```
     pub fn export_dot(&self, config: &DotConfig) -> Result<String> {
         export::export_dot(&self.conn, config)
+    }
+
+    /// Convert this synchronous `KnowledgeGraph` into an `AsyncKnowledgeGraph`.
+    ///
+    /// Requires the `async` feature to be enabled.
+    #[cfg(feature = "async")]
+    pub fn into_async(self) -> AsyncKnowledgeGraph {
+        AsyncKnowledgeGraph::from_sync(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@ pub mod vector;
 #[cfg(feature = "async")]
 pub mod async_kg;
 #[cfg(feature = "async")]
-pub use async_kg::AsyncKnowledgeGraph;
-#[cfg(feature = "async")]
 pub use async_kg::embed::AsyncEmbeddingGenerator;
+#[cfg(feature = "async")]
+pub use async_kg::AsyncKnowledgeGraph;
 
 /// Read a weight column that may be stored as REAL, INTEGER, NULL, or 8-byte BLOB.
 ///

--- a/tests/async_integration.rs
+++ b/tests/async_integration.rs
@@ -38,10 +38,7 @@ async fn test_async_crud_entity() {
     assert_eq!(retrieved.entity_type, "paper");
 
     // List
-    let list = kg
-        .list_entities(Some("paper".into()), None)
-        .await
-        .unwrap();
+    let list = kg.list_entities(Some("paper".into()), None).await.unwrap();
     assert_eq!(list.len(), 1);
 
     // Update
@@ -80,7 +77,10 @@ async fn test_async_insert_relation_and_neighbors() {
 
     // depth-2 from A should reach C as well
     let deep_neighbors = kg.get_neighbors(id_a, 2).await.unwrap();
-    let ids: Vec<i64> = deep_neighbors.iter().map(|n| n.entity.id.unwrap()).collect();
+    let ids: Vec<i64> = deep_neighbors
+        .iter()
+        .map(|n| n.entity.id.unwrap())
+        .collect();
     assert!(ids.contains(&id_b));
     assert!(ids.contains(&id_c));
 }
@@ -270,4 +270,3 @@ async fn test_concurrent_inserts() {
         .unwrap();
     assert_eq!(all.len(), 10);
 }
-

--- a/tests/async_integration.rs
+++ b/tests/async_integration.rs
@@ -1,0 +1,273 @@
+//! Integration tests for the async API.
+//!
+//! Compiled only when the `async` feature is enabled:
+//!   cargo test --features async
+
+#![cfg(feature = "async")]
+
+use std::sync::Arc;
+
+use sqlite_knowledge_graph::{
+    graph::{Entity, Relation},
+    AsyncKnowledgeGraph, Direction, KnowledgeGraph,
+};
+
+// ── Basic construction ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_open_in_memory() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+    // Verify the inner lock is accessible
+    let _inner = kg.inner();
+}
+
+// ── Entity CRUD ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_async_crud_entity() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    // Insert
+    let entity = Entity::new("paper", "Async Test Paper");
+    let id = kg.insert_entity(entity).await.unwrap();
+    assert!(id > 0);
+
+    // Read
+    let retrieved = kg.get_entity(id).await.unwrap();
+    assert_eq!(retrieved.name, "Async Test Paper");
+    assert_eq!(retrieved.entity_type, "paper");
+
+    // List
+    let list = kg
+        .list_entities(Some("paper".into()), None)
+        .await
+        .unwrap();
+    assert_eq!(list.len(), 1);
+
+    // Update
+    let mut updated = retrieved.clone();
+    updated.name = "Updated Title".to_string();
+    kg.update_entity(updated).await.unwrap();
+    let after_update = kg.get_entity(id).await.unwrap();
+    assert_eq!(after_update.name, "Updated Title");
+
+    // Delete
+    kg.delete_entity(id).await.unwrap();
+    let after_delete = kg.get_entity(id).await;
+    assert!(after_delete.is_err());
+}
+
+// ── Relation + neighbors ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_async_insert_relation_and_neighbors() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    let id_a = kg.insert_entity(Entity::new("node", "A")).await.unwrap();
+    let id_b = kg.insert_entity(Entity::new("node", "B")).await.unwrap();
+    let id_c = kg.insert_entity(Entity::new("node", "C")).await.unwrap();
+
+    kg.insert_relation(Relation::new(id_a, id_b, "links_to", 0.9).unwrap())
+        .await
+        .unwrap();
+    kg.insert_relation(Relation::new(id_b, id_c, "links_to", 0.8).unwrap())
+        .await
+        .unwrap();
+
+    let neighbors_a = kg.get_neighbors(id_a, 1).await.unwrap();
+    assert_eq!(neighbors_a.len(), 1);
+    assert_eq!(neighbors_a[0].entity.id.unwrap(), id_b);
+
+    // depth-2 from A should reach C as well
+    let deep_neighbors = kg.get_neighbors(id_a, 2).await.unwrap();
+    let ids: Vec<i64> = deep_neighbors.iter().map(|n| n.entity.id.unwrap()).collect();
+    assert!(ids.contains(&id_b));
+    assert!(ids.contains(&id_c));
+}
+
+// ── Vector search ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_async_vector_search() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    let id = kg
+        .insert_entity(Entity::new("item", "Vector Item"))
+        .await
+        .unwrap();
+
+    let dim = 4usize;
+    let vec_a = vec![1.0f32, 0.0, 0.0, 0.0];
+    let vec_q = vec![1.0f32, 0.1, 0.0, 0.0];
+
+    kg.insert_vector(id, vec_a).await.unwrap();
+
+    let results = kg.search_vectors(vec_q, 1).await.unwrap();
+    assert_eq!(results.len(), 1, "dim={dim}");
+    assert_eq!(results[0].entity_id, id);
+    assert!(results[0].similarity > 0.99);
+}
+
+// ── Graph traversal ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_async_bfs_traversal() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    let root = kg.insert_entity(Entity::new("n", "Root")).await.unwrap();
+    let child1 = kg.insert_entity(Entity::new("n", "Child1")).await.unwrap();
+    let child2 = kg.insert_entity(Entity::new("n", "Child2")).await.unwrap();
+
+    kg.insert_relation(Relation::new(root, child1, "has_child", 1.0).unwrap())
+        .await
+        .unwrap();
+    kg.insert_relation(Relation::new(root, child2, "has_child", 1.0).unwrap())
+        .await
+        .unwrap();
+
+    let nodes = kg
+        .kg_bfs_traversal(root, Direction::Outgoing, 1)
+        .await
+        .unwrap();
+
+    let visited_ids: Vec<i64> = nodes.iter().map(|n| n.entity_id).collect();
+    assert!(visited_ids.contains(&child1));
+    assert!(visited_ids.contains(&child2));
+}
+
+#[tokio::test]
+async fn test_async_shortest_path() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    let a = kg.insert_entity(Entity::new("n", "A")).await.unwrap();
+    let b = kg.insert_entity(Entity::new("n", "B")).await.unwrap();
+    let c = kg.insert_entity(Entity::new("n", "C")).await.unwrap();
+
+    kg.insert_relation(Relation::new(a, b, "edge", 1.0).unwrap())
+        .await
+        .unwrap();
+    kg.insert_relation(Relation::new(b, c, "edge", 1.0).unwrap())
+        .await
+        .unwrap();
+
+    let path = kg.kg_shortest_path(a, c, 5).await.unwrap();
+    assert!(path.is_some());
+    let path = path.unwrap();
+    assert_eq!(path.start_id, a);
+    assert_eq!(path.end_id, c);
+    assert_eq!(path.steps.len(), 2);
+}
+
+// ── Graph algorithms ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_async_pagerank() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    let mut ids = Vec::new();
+    for i in 0..5 {
+        let name = format!("Node {i}");
+        let id = kg.insert_entity(Entity::new("n", &name)).await.unwrap();
+        ids.push(id);
+    }
+
+    // Create a simple ring
+    for i in 0..5 {
+        kg.insert_relation(Relation::new(ids[i], ids[(i + 1) % 5], "edge", 1.0).unwrap())
+            .await
+            .unwrap();
+    }
+
+    let scores = kg.kg_pagerank(None).await.unwrap();
+    assert_eq!(scores.len(), 5);
+    // All scores should sum to ~1.0
+    let sum: f64 = scores.iter().map(|(_, s)| s).sum();
+    assert!((sum - 1.0).abs() < 0.01, "PageRank sum={sum}");
+}
+
+#[tokio::test]
+async fn test_async_graph_stats() {
+    let kg = AsyncKnowledgeGraph::open_in_memory_sync().unwrap();
+
+    let a = kg.insert_entity(Entity::new("n", "A")).await.unwrap();
+    let b = kg.insert_entity(Entity::new("n", "B")).await.unwrap();
+    kg.insert_relation(Relation::new(a, b, "edge", 1.0).unwrap())
+        .await
+        .unwrap();
+
+    let stats = kg.kg_graph_stats().await.unwrap();
+    assert_eq!(stats.total_entities, 2);
+    assert_eq!(stats.total_relations, 1);
+}
+
+// ── Sync ↔ Async interop ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_sync_async_interop() {
+    use tempfile::NamedTempFile;
+
+    // Write via sync API
+    let file = NamedTempFile::new().unwrap();
+    let path = file.path().to_path_buf();
+    {
+        let sync_kg = KnowledgeGraph::open(&path).unwrap();
+        let entity = Entity::new("doc", "Shared Doc");
+        sync_kg.insert_entity(&entity).unwrap();
+    }
+
+    // Read via async API
+    let async_kg = AsyncKnowledgeGraph::open_sync(&path).unwrap();
+    let entities = async_kg
+        .list_entities(Some("doc".into()), None)
+        .await
+        .unwrap();
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].name, "Shared Doc");
+}
+
+#[tokio::test]
+async fn test_into_async_conversion() {
+    let sync_kg = KnowledgeGraph::open_in_memory().unwrap();
+
+    // Insert via sync
+    let entity = Entity::new("test", "Converted");
+    sync_kg.insert_entity(&entity).unwrap();
+
+    // Convert and read via async
+    let async_kg = sync_kg.into_async();
+    let entities = async_kg
+        .list_entities(Some("test".into()), None)
+        .await
+        .unwrap();
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].name, "Converted");
+}
+
+// ── Concurrency ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_concurrent_inserts() {
+    let kg = Arc::new(AsyncKnowledgeGraph::open_in_memory_sync().unwrap());
+
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let kg = Arc::clone(&kg);
+            tokio::spawn(async move {
+                let name = format!("Concurrent Entity {i}");
+                kg.insert_entity(Entity::new("concurrent", &name)).await
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        let result = handle.await.unwrap();
+        assert!(result.is_ok(), "concurrent insert failed: {result:?}");
+    }
+
+    let all = kg
+        .list_entities(Some("concurrent".into()), None)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 10);
+}
+


### PR DESCRIPTION
## Summary

- 新增 `AsyncKnowledgeGraph`（`Arc<Mutex<KnowledgeGraph>>`），通过 `tokio::task::spawn_blocking` 将所有阻塞 SQLite 操作派发到独立线程，Tokio executor 不再被阻塞
- 新增 `AsyncEmbeddingGenerator`，使用 `tokio::process::Command` 驱动 Python subprocess，Python 嵌入生成（2–10s/批次）不再占用 blocking 线程池槽
- 整个 async 层通过 `features = ["async"]` 门控，cdylib 扩展场景零开销
- 同步 API 完全不变，现有用户零迁移成本

## Changes

| 文件 | 变更 |
|------|------|
| `src/async_kg/mod.rs` | 新建：`AsyncKnowledgeGraph` + 全量 async 方法 + `dispatch!` macro |
| `src/async_kg/embed.rs` | 新建：`AsyncEmbeddingGenerator`（tokio::process） |
| `src/error.rs` | 新增 `TaskPanicked(String)` variant |
| `Cargo.toml` | 新增 optional tokio + `features = ["async"]` |
| `src/lib.rs` | 注册 `async_kg` 模块，`into_async()` 转换方法 |
| `tests/async_integration.rs` | 11 个集成测试（含并发插入验证） |
| `examples/async_demo.rs` | 端到端演示：20 篇论文并发插入 + PageRank + 语义搜索 + 最短路径 |
| `README.md` / `AGENTS.md` / `docs/quality/domains.md` | 文档更新 |

## Test plan

- [x] `cargo test` — 114 passed（同步 API 未受影响）
- [x] `cargo test --features async` — 122 unit + 11 integration = 133 passed
- [x] `cargo clippy --features async -- -D warnings` — 零警告
- [x] `cargo run --example async_demo --features async` — 端到端 demo 运行正常

## Design Notes

- 不采用 `tokio-rusqlite`：`RagEngine` 多步管道和 `transaction()` 跨步操作无法拆分为独立闭包
- `MutexGuard` 不跨 `.await`：lock 在 `spawn_blocking` 闭包内获取和释放
- async 方法参数改为 owned（`entity: Entity` 而非 `&Entity`），闭包需要 `'static`
- 并发读场景建议开多个实例（SQLite WAL 支持并发读）

🤖 Generated with [Claude Code](https://claude.com/claude-code)