### PR TITLE
feat: SmartVector self-aware vector embeddings (arXiv:2604.20598)

### DIFF
--- a/openspec/smartvector.spec.md
+++ b/openspec/smartvector.spec.md
@@ -1,0 +1,141 @@
+# SmartVector: Self-Aware Vector Embeddings for sqlite-knowledge-graph
+
+## Background
+
+Based on arXiv:2604.20598 (SmartVector, April 2026), this spec defines adding temporal awareness, confidence decay, and relational dependency tracking to the existing knowledge graph system.
+
+## Requirements
+
+### Requirement: Temporal Awareness for Entities
+The system SHALL track creation time, last access time, and validity windows for all entities and relations.
+
+#### Scenario: Entity creation includes timestamp
+GIVEN a new entity is inserted via `insert_entity`
+WHEN the entity is stored
+THEN the `created_at` field is automatically set to current Unix timestamp
+AND `confidence` defaults to 1.0
+AND `access_count` defaults to 0
+
+#### Scenario: Entity access updates tracking
+GIVEN an existing entity with id=123
+WHEN `access_entity(123)` is called
+THEN the entity's `access_count` is incremented by 1
+AND `last_accessed` is updated to current timestamp
+
+#### Scenario: Entity query filters by temporal range
+GIVEN entities with various creation dates
+WHEN `query_entities` is called with `created_after` and `created_before` filters
+THEN only entities within the specified time range are returned
+
+### Requirement: Confidence Decay Engine
+The system SHALL implement a confidence scoring mechanism based on Ebbinghaus forgetting curve, access reinforcement, and feedback adjustment.
+
+#### Scenario: Confidence decays over time
+GIVEN an entity with initial confidence=1.0 created 30 days ago
+WHEN `get_confidence(entity_id)` is called
+THEN the returned confidence is < 1.0 (decayed by Ebbinghaus function)
+
+#### Scenario: Access reinforces confidence
+GIVEN an entity whose confidence has decayed to 0.5
+WHEN `access_entity(entity_id)` is called
+THEN the entity's confidence increases (reinforcement effect)
+
+#### Scenario: Feedback adjusts confidence
+GIVEN an entity with confidence=0.8
+WHEN `update_confidence(entity_id, feedback=-0.2)` is called for negative feedback
+THEN the entity's confidence is reduced to 0.6
+AND the change is logged
+
+#### Scenario: Confidence formula
+The confidence function SHALL be:
+```
+confidence(t) = base * exp(-lambda * elapsed_days) 
+              + access_bonus * log(1 + access_count) 
+              + feedback_sum
+```
+Where:
+- `base` = initial confidence (default 1.0)
+- `lambda` = decay rate (default 0.05/day)
+- `access_bonus` = reinforcement factor (default 0.1)
+- `feedback_sum` = sum of all feedback adjustments (bounded to [-1, 1])
+
+### Requirement: Dependency Graph & Ripple Propagation
+The system SHALL track dependency relationships between entities and propagate updates along dependency edges.
+
+#### Scenario: Dependency edges are stored
+GIVEN entity A depends on entity B
+WHEN `add_dependency(A_id, B_id, "supersedes")` is called
+THEN a record is created in `kg_dependencies` table
+AND the dependency type is stored
+
+#### Scenario: Ripple propagation on update
+GIVEN entity B has been superseded by entity A
+AND entity C depends on entity B
+WHEN entity B is updated or marked stale
+THEN the RipplePropagator propagates a confidence penalty to entity C
+AND the penalty is attenuated by hop distance (max depth = 2)
+
+#### Scenario: Dependency types
+The system SHALL support the following dependency types:
+- `depends_on` — A requires B to be valid
+- `depended_by` — B is required by A
+- `supersedes` — A replaces B
+- `contradicts` — A conflicts with B
+
+### Requirement: Four-Signal Retrieval Scoring
+The system SHALL replace pure cosine similarity with a four-signal scoring function for vector retrieval.
+
+#### Scenario: Four-signal retrieval score
+GIVEN a query vector and a corpus of entities with vectors
+WHEN `retrieve_with_four_signal(query_vector, top_k)` is called
+THEN each candidate is scored as:
+```
+final_score = w1 * cosine_similarity 
+            + w2 * temporal_validity 
+            + w3 * live_confidence 
+            + w4 * graph_importance
+```
+WHERE:
+- `cosine_similarity` = standard vector cosine similarity
+- `temporal_validity` = 1.0 if within validity window, decaying otherwise
+- `live_confidence` = current confidence score from ConfidenceEngine
+- `graph_importance` = PageRank-style importance from dependency graph
+- Default weights: w1=0.5, w2=0.2, w3=0.2, w4=0.1
+
+#### Scenario: Configurable weights
+GIVEN the retrieval system
+WHEN `set_retrieval_weights(w1, w2, w3, w4)` is called
+THEN subsequent retrievals use the new weights
+
+### Requirement: Schema Migration v3
+The system SHALL add new columns and tables via a non-destructive migration.
+
+#### Scenario: Migration preserves existing data
+GIVEN a database at schema version 2 with existing entities, relations, and vectors
+WHEN `ensure_schema` is called on a library version that supports v3
+THEN all existing data is preserved
+AND new columns/tables are added
+AND schema version is updated to 3
+
+#### Scenario: New schema tables
+Migration v3 SHALL create:
+- `kg_dependencies` table: entity dependencies (source_id, target_id, dep_type, created_at)
+- `kg_confidence_log` table: confidence change history (entity_id, old_value, new_value, reason, timestamp)
+- New columns on `kg_entities`: `confidence`, `access_count`, `last_accessed`, `valid_from`, `valid_until`, `base_confidence`, `decay_rate`
+- New columns on `kg_relations`: `confidence`, `valid_from`, `valid_until`
+
+### Requirement: Performance & Benchmarking
+The system SHALL maintain performance within acceptable bounds and provide benchmarking tools.
+
+#### Scenario: Benchmark suite runs
+GIVEN a test database with 10,000+ entities
+WHEN `cargo bench` is run
+THEN retrieval latency with four-signal scoring is within 2x of pure cosine retrieval
+AND confidence computation is O(1) per entity (cached)
+AND ripple propagation completes in < 100ms for graphs up to depth 2
+
+#### Scenario: Memory overhead is bounded
+GIVEN a database with 100,000 entities
+WHEN SmartVector features are enabled
+THEN memory overhead is < 10% compared to baseline
+AND confidence cache uses < 50MB for 100K entities

--- a/src/graph/entity.rs
+++ b/src/graph/entity.rs
@@ -83,9 +83,11 @@ pub fn get_entity(conn: &rusqlite::Connection, id: i64) -> Result<Entity> {
     )?;
 
     let entity = stmt.query_row(params![id], |row| {
-        let properties_json: String = row.get(3)?;
-        let properties: HashMap<String, serde_json::Value> =
-            serde_json::from_str(&properties_json).unwrap_or_default();
+        let properties_json: Option<String> = row.get(3)?;
+        let properties: HashMap<String, serde_json::Value> = match properties_json {
+            Some(json) => serde_json::from_str(&json).unwrap_or_default(),
+            None => HashMap::new(),
+        };
 
         Ok(Entity {
             id: Some(row.get(0)?),

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,6 +3,7 @@
 pub mod entity;
 pub mod hyperedge;
 pub mod relation;
+pub mod ripple;
 pub mod traversal;
 
 pub use entity::{delete_entity, get_entity, insert_entity, list_entities, update_entity, Entity};
@@ -13,6 +14,7 @@ pub use hyperedge::{
     HigherOrderPath, HigherOrderPathStep, Hyperedge,
 };
 pub use relation::{get_neighbors, get_relations_by_source, insert_relation, Neighbor, Relation};
+pub use ripple::{add_dependency, propagate as ripple_propagate};
 pub use traversal::{
     bfs_traversal, compute_graph_stats, dfs_traversal, find_shortest_path, Direction, GraphStats,
     PathStep, TraversalNode, TraversalPath, TraversalQuery,

--- a/src/graph/ripple.rs
+++ b/src/graph/ripple.rs
@@ -1,0 +1,249 @@
+//! Ripple propagation of confidence penalties along dependency edges.
+//!
+//! When an entity becomes stale or its confidence drops, dependent entities
+//! receive an attenuated penalty via BFS up to `MAX_DEPTH = 2` hops.
+//! Every change is appended to `kg_confidence_log`.
+
+use crate::error::Result;
+use crate::vector::confidence::now_unix;
+use rusqlite::Connection;
+use std::collections::{HashSet, VecDeque};
+use tracing::debug;
+
+const MAX_DEPTH: usize = 2;
+const ATTENUATION: f64 = 0.5;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Propagate a confidence penalty from `origin_id` to all entities that
+/// transitively depend on it, up to `MAX_DEPTH` hops.
+///
+/// Penalty at hop *h* = `base_penalty * ATTENUATION^h`.
+pub fn propagate(conn: &Connection, origin_id: i64, base_penalty: f64) -> Result<()> {
+    // BFS queue: (entity_id, hop_depth)
+    let mut queue: VecDeque<(i64, usize)> = VecDeque::new();
+    let mut visited: HashSet<i64> = HashSet::new();
+    visited.insert(origin_id);
+    queue.push_back((origin_id, 0));
+
+    while let Some((current_id, depth)) = queue.pop_front() {
+        if depth >= MAX_DEPTH {
+            continue;
+        }
+
+        let next_depth = depth + 1;
+        let actual_penalty = base_penalty * ATTENUATION.powi(next_depth as i32);
+
+        // Find entities whose confidence depends_on current_id
+        let dependents = dependents_of(conn, current_id)?;
+
+        for dep_id in dependents {
+            if visited.contains(&dep_id) {
+                continue;
+            }
+            visited.insert(dep_id);
+
+            apply_penalty(conn, dep_id, actual_penalty)?;
+            debug!(
+                dep_id,
+                depth = next_depth,
+                actual_penalty,
+                "ripple penalty applied"
+            );
+            queue.push_back((dep_id, next_depth));
+        }
+    }
+
+    Ok(())
+}
+
+/// Insert a dependency edge: `source_id` depends on `target_id`.
+///
+/// `dep_type` should be one of: `depends_on`, `depended_by`, `supersedes`,
+/// `contradicts`.
+pub fn add_dependency(
+    conn: &Connection,
+    source_id: i64,
+    target_id: i64,
+    dep_type: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO kg_dependencies (source_id, target_id, dep_type, created_at) \
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![source_id, target_id, dep_type, now_unix()],
+    )?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn dependents_of(conn: &Connection, target_id: i64) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT source_id FROM kg_dependencies \
+         WHERE target_id = ?1 AND dep_type = 'depends_on'",
+    )?;
+    let ids = stmt
+        .query_map([target_id], |r| r.get::<_, i64>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(ids)
+}
+
+fn apply_penalty(conn: &Connection, entity_id: i64, penalty: f64) -> Result<()> {
+    let old_conf: f64 = conn.query_row(
+        "SELECT COALESCE(confidence, 1.0) FROM kg_entities WHERE id = ?1",
+        [entity_id],
+        |r| r.get(0),
+    )?;
+    let raw_conf = old_conf - penalty;
+    let new_conf = raw_conf.clamp(0.0, 1.0);
+
+    conn.execute(
+        "UPDATE kg_entities SET confidence = ?1 WHERE id = ?2",
+        rusqlite::params![new_conf, entity_id],
+    )?;
+    conn.execute(
+        "INSERT INTO kg_confidence_log \
+         (entity_id, old_value, new_value, reason, created_at) \
+         VALUES (?1, ?2, ?3, 'ripple', ?4)",
+        rusqlite::params![entity_id, old_conf, new_conf, now_unix()],
+    )?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::ensure_schema;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        conn
+    }
+
+    fn insert_entity(conn: &Connection, name: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name, confidence) VALUES ('t', ?1, 1.0)",
+            [name],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn get_confidence(conn: &Connection, id: i64) -> f64 {
+        conn.query_row(
+            "SELECT confidence FROM kg_entities WHERE id = ?1",
+            [id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn add_dependency_inserts_row() {
+        let conn = setup();
+        let a = insert_entity(&conn, "A");
+        let b = insert_entity(&conn, "B");
+        add_dependency(&conn, a, b, "depends_on").unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM kg_dependencies", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn ripple_penalises_direct_dependent() {
+        let conn = setup();
+        let b = insert_entity(&conn, "B");
+        let a = insert_entity(&conn, "A");
+        add_dependency(&conn, a, b, "depends_on").unwrap(); // A depends on B
+
+        propagate(&conn, b, 0.4).unwrap();
+
+        // A should have been penalised at depth 1: penalty = 0.4 * 0.5 = 0.2
+        let conf_a = get_confidence(&conn, a);
+        assert!((conf_a - 0.8).abs() < 1e-9, "expected 0.8, got {conf_a}");
+    }
+
+    #[test]
+    fn ripple_attenuates_at_depth_two() {
+        let conn = setup();
+        let c_node = insert_entity(&conn, "C"); // C depends on B
+        let b = insert_entity(&conn, "B"); // B depends on A
+        let a = insert_entity(&conn, "A"); // origin: A becomes stale
+
+        add_dependency(&conn, b, a, "depends_on").unwrap();
+        add_dependency(&conn, c_node, b, "depends_on").unwrap();
+
+        propagate(&conn, a, 0.4).unwrap();
+
+        let conf_b = get_confidence(&conn, b);
+        let conf_c = get_confidence(&conn, c_node);
+
+        // depth 1: 0.4 * 0.5 = 0.2 → conf_b = 0.8
+        assert!((conf_b - 0.8).abs() < 1e-9, "expected 0.8, got {conf_b}");
+        // depth 2: 0.4 * 0.25 = 0.1 → conf_c = 0.9
+        assert!((conf_c - 0.9).abs() < 1e-9, "expected 0.9, got {conf_c}");
+    }
+
+    #[test]
+    fn ripple_logs_changes() {
+        let conn = setup();
+        let b = insert_entity(&conn, "B");
+        let a = insert_entity(&conn, "A");
+        add_dependency(&conn, a, b, "depends_on").unwrap();
+
+        propagate(&conn, b, 0.2).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_confidence_log WHERE reason = 'ripple'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn ripple_stops_at_max_depth() {
+        let conn = setup();
+        // Chain: D → C → B → A  (A is origin)
+        let d = insert_entity(&conn, "D");
+        let c_node = insert_entity(&conn, "C");
+        let b = insert_entity(&conn, "B");
+        let a = insert_entity(&conn, "A");
+
+        add_dependency(&conn, b, a, "depends_on").unwrap();
+        add_dependency(&conn, c_node, b, "depends_on").unwrap();
+        add_dependency(&conn, d, c_node, "depends_on").unwrap();
+
+        propagate(&conn, a, 0.4).unwrap();
+
+        // D is at depth 3 — should NOT be penalised
+        let conf_d = get_confidence(&conn, d);
+        assert!((conf_d - 1.0).abs() < 1e-9, "D should be unaffected");
+    }
+
+    #[test]
+    fn apply_penalty_clamps_to_zero_when_penalty_exceeds_confidence() {
+        let conn = setup();
+        let a = insert_entity(&conn, "A");
+
+        // penalty larger than the starting confidence of 1.0
+        apply_penalty(&conn, a, 1.5).unwrap();
+
+        let conf = get_confidence(&conn, a);
+        assert!(conf >= 0.0, "confidence must not be negative, got {conf}");
+        assert!((conf - 0.0).abs() < 1e-9, "expected 0.0, got {conf}");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,10 @@ pub use migrate::{
     build_relationships, migrate_all, migrate_papers, migrate_skills, MigrationStats,
 };
 pub use rag::{embedder::Embedder, embedder::FixedEmbedder, RagConfig, RagEngine, RagResult};
+pub use rag::{RetrievalWeights, SmartRetrieval, SmartSearchResult};
 pub use schema::{create_schema, schema_exists};
 pub use vector::{cosine_similarity, SearchResult, VectorStore};
+pub use vector::{ConfidenceEngine, ConfidenceParams};
 pub use vector::{TurboQuantConfig, TurboQuantIndex, TurboQuantStats};
 
 use rusqlite::Connection;
@@ -115,9 +117,15 @@ pub struct HybridSearchResult {
 }
 
 /// Knowledge Graph Manager - main entry point for the library.
-#[derive(Debug)]
 pub struct KnowledgeGraph {
     conn: Connection,
+    retrieval_weights: std::cell::Cell<RetrievalWeights>,
+}
+
+impl std::fmt::Debug for KnowledgeGraph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KnowledgeGraph").finish_non_exhaustive()
+    }
 }
 
 impl KnowledgeGraph {
@@ -136,7 +144,10 @@ impl KnowledgeGraph {
         // Register custom functions
         register_functions(&conn)?;
 
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            retrieval_weights: std::cell::Cell::new(RetrievalWeights::default()),
+        })
     }
 
     /// Open an in-memory knowledge graph (useful for testing).
@@ -152,12 +163,25 @@ impl KnowledgeGraph {
         // Register custom functions
         register_functions(&conn)?;
 
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            retrieval_weights: std::cell::Cell::new(RetrievalWeights::default()),
+        })
     }
 
     /// Get a reference to the underlying SQLite connection.
     pub fn connection(&self) -> &Connection {
         &self.conn
+    }
+
+    /// Get the current SmartVector retrieval weights.
+    pub fn retrieval_weights(&self) -> RetrievalWeights {
+        self.retrieval_weights.get()
+    }
+
+    /// Set SmartVector retrieval weights.
+    pub fn set_retrieval_weights(&self, weights: RetrievalWeights) {
+        self.retrieval_weights.set(weights);
     }
 
     /// Begin a transaction for batch operations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,14 @@ impl KnowledgeGraph {
         store.search_vectors(&self.conn, query, k)
     }
 
+    /// Search using the four-signal SmartVector formula (cosine × temporal × confidence × graph importance).
+    ///
+    /// Weights are configured via [`set_retrieval_weights`](Self::set_retrieval_weights).
+    pub fn smart_search(&self, query: Vec<f32>, k: usize) -> Result<Vec<SmartSearchResult>> {
+        let retrieval = SmartRetrieval::new(self.retrieval_weights.get());
+        retrieval.retrieve(&self.conn, &query, k)
+    }
+
     // ========== TurboQuant Vector Index ==========
 
     /// Create a TurboQuant index for fast approximate nearest neighbor search.

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -22,9 +22,11 @@
 
 pub mod embedder;
 mod error;
+pub mod smart_retrieval;
 
 pub use embedder::Embedder;
 pub use error::RagError;
+pub use smart_retrieval::{RetrievalWeights, SmartRetrieval, SmartSearchResult};
 
 use crate::error::Result;
 use crate::graph::{get_neighbors, Entity};

--- a/src/rag/smart_retrieval.rs
+++ b/src/rag/smart_retrieval.rs
@@ -1,0 +1,338 @@
+//! Four-signal retrieval scoring for SmartVector.
+//!
+//! Final score = w1·cosine + w2·temporal + w3·confidence + w4·graph_importance
+//!
+//! Default weights: w1=0.5, w2=0.2, w3=0.2, w4=0.1.
+
+use crate::error::{Error, Result};
+use crate::graph::get_entity;
+use crate::vector::confidence::now_unix;
+use crate::vector::VectorStore;
+use rusqlite::Connection;
+use std::collections::HashMap;
+use tracing::debug;
+
+const TEMPORAL_DECAY_FACTOR: f64 = 0.1; // per-day decay outside validity window
+const SECS_PER_DAY: f64 = 86_400.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Blending weights for the four retrieval signals.
+#[derive(Debug, Clone, Copy)]
+pub struct RetrievalWeights {
+    pub w1: f64, // cosine similarity
+    pub w2: f64, // temporal validity
+    pub w3: f64, // live confidence
+    pub w4: f64, // graph importance
+}
+
+impl Default for RetrievalWeights {
+    fn default() -> Self {
+        Self {
+            w1: 0.5,
+            w2: 0.2,
+            w3: 0.2,
+            w4: 0.1,
+        }
+    }
+}
+
+/// One result from four-signal retrieval.
+#[derive(Debug, Clone)]
+pub struct SmartSearchResult {
+    pub entity: crate::graph::Entity,
+    pub final_score: f64,
+    pub cosine_score: f64,
+    pub temporal_score: f64,
+    pub confidence_score: f64,
+    pub graph_importance: f64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SmartRetrieval
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Retrieval engine that combines four signals.
+#[derive(Default)]
+pub struct SmartRetrieval {
+    pub weights: RetrievalWeights,
+}
+
+impl SmartRetrieval {
+    pub fn new(weights: RetrievalWeights) -> Self {
+        Self { weights }
+    }
+
+    pub fn set_weights(&mut self, weights: RetrievalWeights) {
+        self.weights = weights;
+    }
+
+    /// Retrieve top-`k` entities scored by the four-signal formula.
+    pub fn retrieve(
+        &self,
+        conn: &Connection,
+        query: &[f32],
+        top_k: usize,
+    ) -> Result<Vec<SmartSearchResult>> {
+        let store = VectorStore::new();
+        // Fetch a larger candidate pool so re-ranking has enough options.
+        let pool_size = (top_k * 3).max(20);
+        let candidates = store.search_vectors(conn, query.to_vec(), pool_size)?;
+
+        if candidates.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ids: Vec<i64> = candidates.iter().map(|c| c.entity_id).collect();
+        let indegrees = load_indegrees(conn, &ids)?;
+        let max_indegree = indegrees.values().copied().fold(0u32, u32::max);
+        let now = now_unix();
+
+        let mut results = Vec::with_capacity(candidates.len());
+        for candidate in &candidates {
+            let eid = candidate.entity_id;
+            let cosine = candidate.similarity as f64;
+            let temporal = temporal_validity(conn, eid, now)?;
+            let conf = cached_confidence(conn, eid)?;
+            let importance = if max_indegree > 0 {
+                *indegrees.get(&eid).unwrap_or(&0) as f64 / max_indegree as f64
+            } else {
+                0.0
+            };
+
+            let final_score = self.weights.w1 * cosine
+                + self.weights.w2 * temporal
+                + self.weights.w3 * conf
+                + self.weights.w4 * importance;
+
+            let entity = get_entity(conn, eid)?;
+            results.push(SmartSearchResult {
+                entity,
+                final_score,
+                cosine_score: cosine,
+                temporal_score: temporal,
+                confidence_score: conf,
+                graph_importance: importance,
+            });
+        }
+
+        results.sort_by(|a, b| {
+            b.final_score
+                .partial_cmp(&a.final_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        results.truncate(top_k);
+
+        debug!(
+            top_k,
+            found = results.len(),
+            "four-signal retrieval complete"
+        );
+        Ok(results)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Signal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn load_indegrees(conn: &Connection, ids: &[i64]) -> Result<HashMap<i64, u32>> {
+    let mut map = HashMap::with_capacity(ids.len());
+    for &id in ids {
+        let count: u32 = conn.query_row(
+            "SELECT COUNT(*) FROM kg_dependencies WHERE target_id = ?1",
+            [id],
+            |r| r.get(0),
+        )?;
+        map.insert(id, count);
+    }
+    Ok(map)
+}
+
+/// Returns a score in [0, 1] reflecting how valid the entity is right now.
+fn temporal_validity(conn: &Connection, entity_id: i64, now: i64) -> Result<f64> {
+    let (valid_from, valid_until): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT valid_from, valid_until FROM kg_entities WHERE id = ?1",
+            [entity_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Error::EntityNotFound(entity_id),
+            other => Error::SQLite(other),
+        })?;
+
+    if let Some(from) = valid_from {
+        if now < from {
+            return Ok(0.0); // not yet valid
+        }
+    }
+    if let Some(until) = valid_until {
+        if now > until {
+            let days_over = (now - until) as f64 / SECS_PER_DAY;
+            return Ok((-TEMPORAL_DECAY_FACTOR * days_over).exp());
+        }
+    }
+    Ok(1.0)
+}
+
+fn cached_confidence(conn: &Connection, entity_id: i64) -> Result<f64> {
+    conn.query_row(
+        "SELECT COALESCE(confidence, 1.0) FROM kg_entities WHERE id = ?1",
+        [entity_id],
+        |r| r.get(0),
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Error::EntityNotFound(entity_id),
+        other => Error::SQLite(other),
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::ensure_schema;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        conn
+    }
+
+    fn add_entity_with_vector(conn: &Connection, name: &str, vec: &[f32]) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('t', ?1)",
+            [name],
+        )
+        .unwrap();
+        let id = conn.last_insert_rowid();
+        let store = VectorStore::new();
+        store.insert_vector(conn, id, vec.to_vec()).unwrap();
+        id
+    }
+
+    #[test]
+    fn retrieves_top_k_results() {
+        let conn = setup();
+        add_entity_with_vector(&conn, "A", &[1.0, 0.0, 0.0]);
+        add_entity_with_vector(&conn, "B", &[0.9, 0.1, 0.0]);
+        add_entity_with_vector(&conn, "C", &[0.0, 0.0, 1.0]);
+
+        let sr = SmartRetrieval::default();
+        let results = sr.retrieve(&conn, &[1.0, 0.0, 0.0], 2).unwrap();
+        assert_eq!(results.len(), 2);
+        // A or B should be at the top (most similar to query)
+        assert!(results[0].cosine_score >= results[1].cosine_score - 0.1);
+    }
+
+    #[test]
+    fn temporal_past_window_decays_score() {
+        let conn = setup();
+        let id = add_entity_with_vector(&conn, "old", &[1.0, 0.0]);
+        // Set valid_until 365 days in the past
+        let past = now_unix() - 365 * 86400;
+        conn.execute(
+            "UPDATE kg_entities SET valid_until = ?1 WHERE id = ?2",
+            rusqlite::params![past, id],
+        )
+        .unwrap();
+
+        let score = temporal_validity(&conn, id, now_unix()).unwrap();
+        assert!(
+            score < 0.01,
+            "expired entity should have near-zero temporal score"
+        );
+    }
+
+    #[test]
+    fn temporal_future_window_returns_zero() {
+        let conn = setup();
+        let id = add_entity_with_vector(&conn, "future", &[1.0, 0.0]);
+        let future = now_unix() + 86400;
+        conn.execute(
+            "UPDATE kg_entities SET valid_from = ?1 WHERE id = ?2",
+            rusqlite::params![future, id],
+        )
+        .unwrap();
+
+        let score = temporal_validity(&conn, id, now_unix()).unwrap();
+        assert_eq!(
+            score, 0.0,
+            "not-yet-valid entity should have zero temporal score"
+        );
+    }
+
+    #[test]
+    fn configurable_weights_affect_ranking() {
+        let conn = setup();
+        let _id_a = add_entity_with_vector(&conn, "A", &[1.0, 0.0]);
+        let id_b = add_entity_with_vector(&conn, "B", &[0.5, 0.5]);
+
+        // Give B higher confidence
+        conn.execute(
+            "UPDATE kg_entities SET confidence = 2.0 WHERE id = ?1",
+            [id_b],
+        )
+        .unwrap();
+
+        // High confidence weight: B might rank above A despite lower cosine
+        let mut sr = SmartRetrieval::default();
+        sr.set_weights(RetrievalWeights {
+            w1: 0.1,
+            w2: 0.1,
+            w3: 0.7,
+            w4: 0.1,
+        });
+        let results = sr.retrieve(&conn, &[1.0, 0.0], 2).unwrap();
+        assert_eq!(results.len(), 2);
+        // B should now rank first due to high confidence weight
+        assert_eq!(results[0].entity.id, Some(id_b));
+    }
+
+    #[test]
+    fn graph_importance_boosts_score() {
+        let conn = setup();
+        let _id_a = add_entity_with_vector(&conn, "A", &[1.0, 0.0]);
+        let id_b = add_entity_with_vector(&conn, "B", &[1.0, 0.0]);
+
+        // Make several entities depend on B (high in-degree)
+        for _ in 0..5 {
+            conn.execute(
+                "INSERT INTO kg_entities (entity_type, name) VALUES ('dep', 'dep')",
+                [],
+            )
+            .unwrap();
+            let dep_id = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO kg_dependencies (source_id, target_id, dep_type) VALUES (?1, ?2, 'depends_on')",
+                rusqlite::params![dep_id, id_b],
+            )
+            .unwrap();
+        }
+
+        let sr = SmartRetrieval::new(RetrievalWeights {
+            w1: 0.0,
+            w2: 0.0,
+            w3: 0.0,
+            w4: 1.0, // only graph importance
+        });
+        let results = sr.retrieve(&conn, &[1.0, 0.0], 2).unwrap();
+        assert_eq!(results.len(), 2);
+        // B has higher in-degree so should rank first
+        assert_eq!(
+            results[0].entity.id,
+            Some(id_b),
+            "high in-degree entity should rank first"
+        );
+        assert!(
+            results[0].graph_importance > results[1].graph_importance,
+            "importance should be normalised"
+        );
+    }
+}

--- a/src/rag/smart_retrieval.rs
+++ b/src/rag/smart_retrieval.rs
@@ -6,7 +6,7 @@
 
 use crate::error::{Error, Result};
 use crate::graph::get_entity;
-use crate::vector::confidence::now_unix;
+use crate::vector::confidence::{now_unix, ConfidenceEngine};
 use crate::vector::VectorStore;
 use rusqlite::Connection;
 use std::collections::HashMap;
@@ -95,7 +95,7 @@ impl SmartRetrieval {
             let eid = candidate.entity_id;
             let cosine = candidate.similarity as f64;
             let temporal = temporal_validity(conn, eid, now)?;
-            let conf = cached_confidence(conn, eid)?;
+            let conf = ConfidenceEngine::default().get_confidence(conn, eid)?;
             let importance = if max_indegree > 0 {
                 *indegrees.get(&eid).unwrap_or(&0) as f64 / max_indegree as f64
             } else {
@@ -139,13 +139,25 @@ impl SmartRetrieval {
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn load_indegrees(conn: &Connection, ids: &[i64]) -> Result<HashMap<i64, u32>> {
-    let mut map = HashMap::with_capacity(ids.len());
-    for &id in ids {
-        let count: u32 = conn.query_row(
-            "SELECT COUNT(*) FROM kg_dependencies WHERE target_id = ?1",
-            [id],
-            |r| r.get(0),
-        )?;
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    // Build a single grouped query instead of one SELECT per id.
+    let placeholders = ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT target_id, COUNT(*) FROM kg_dependencies WHERE target_id IN ({placeholders}) GROUP BY target_id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params = rusqlite::params_from_iter(ids.iter());
+    let mut map: HashMap<i64, u32> = ids.iter().map(|&id| (id, 0)).collect();
+    let rows = stmt.query_map(params, |r| Ok((r.get::<_, i64>(0)?, r.get::<_, u32>(1)?)))?;
+    for row in rows {
+        let (id, count) = row?;
         map.insert(id, count);
     }
     Ok(map)
@@ -176,18 +188,6 @@ fn temporal_validity(conn: &Connection, entity_id: i64, now: i64) -> Result<f64>
         }
     }
     Ok(1.0)
-}
-
-fn cached_confidence(conn: &Connection, entity_id: i64) -> Result<f64> {
-    conn.query_row(
-        "SELECT COALESCE(confidence, 1.0) FROM kg_entities WHERE id = ?1",
-        [entity_id],
-        |r| r.get(0),
-    )
-    .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => Error::EntityNotFound(entity_id),
-        other => Error::SQLite(other),
-    })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -274,9 +274,9 @@ mod tests {
         let _id_a = add_entity_with_vector(&conn, "A", &[1.0, 0.0]);
         let id_b = add_entity_with_vector(&conn, "B", &[0.5, 0.5]);
 
-        // Give B higher confidence
+        // Give B higher base_confidence so the live formula returns a higher score.
         conn.execute(
-            "UPDATE kg_entities SET confidence = 2.0 WHERE id = ?1",
+            "UPDATE kg_entities SET base_confidence = 2.0 WHERE id = ?1",
             [id_b],
         )
         .unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -246,9 +246,11 @@ fn migration_v3(conn: &Connection) -> Result<()> {
             old_value  REAL    NOT NULL,
             new_value  REAL    NOT NULL,
             reason     TEXT    NOT NULL,
-            created_at INTEGER DEFAULT (strftime('%s', 'now'))
+            created_at INTEGER DEFAULT (strftime('%s', 'now')),
+            FOREIGN KEY (entity_id) REFERENCES kg_entities(id) ON DELETE CASCADE
         );
         CREATE INDEX IF NOT EXISTS idx_conf_log_entity ON kg_confidence_log(entity_id);
+        CREATE INDEX IF NOT EXISTS idx_conf_log_entity_reason ON kg_confidence_log(entity_id, reason);
     "#,
     )?;
     Ok(())

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -16,7 +16,7 @@ use rusqlite::Connection;
 use crate::error::{Error, Result};
 
 /// Latest known schema version.  Bump this whenever a new migration is added.
-const CURRENT_SCHEMA_VERSION: i32 = 2;
+const CURRENT_SCHEMA_VERSION: i32 = 3;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
@@ -107,6 +107,7 @@ fn apply_migration(conn: &Connection, version: i32) -> Result<()> {
     match version {
         1 => migration_v1(conn),
         2 => migration_v2(conn),
+        3 => migration_v3(conn),
         _ => Err(Error::Other(format!(
             "Unknown schema migration version: {}",
             version
@@ -206,6 +207,53 @@ fn migration_v2(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Migration v3 — SmartVector: temporal awareness, confidence decay, dependencies.
+///
+/// Adds new columns to `kg_entities` and `kg_relations`, and creates two new
+/// tables (`kg_dependencies`, `kg_confidence_log`) for dependency tracking and
+/// confidence change history.  All changes are non-destructive: existing rows
+/// receive column defaults and are otherwise untouched.
+fn migration_v3(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        ALTER TABLE kg_entities ADD COLUMN confidence      REAL    DEFAULT 1.0;
+        ALTER TABLE kg_entities ADD COLUMN access_count   INTEGER DEFAULT 0;
+        ALTER TABLE kg_entities ADD COLUMN last_accessed  INTEGER;
+        ALTER TABLE kg_entities ADD COLUMN valid_from     INTEGER;
+        ALTER TABLE kg_entities ADD COLUMN valid_until    INTEGER;
+        ALTER TABLE kg_entities ADD COLUMN base_confidence REAL   DEFAULT 1.0;
+        ALTER TABLE kg_entities ADD COLUMN decay_rate     REAL    DEFAULT 0.05;
+
+        ALTER TABLE kg_relations ADD COLUMN confidence  REAL    DEFAULT 1.0;
+        ALTER TABLE kg_relations ADD COLUMN valid_from  INTEGER;
+        ALTER TABLE kg_relations ADD COLUMN valid_until INTEGER;
+
+        CREATE TABLE IF NOT EXISTS kg_dependencies (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id INTEGER NOT NULL,
+            target_id INTEGER NOT NULL,
+            dep_type  TEXT    NOT NULL,
+            created_at INTEGER DEFAULT (strftime('%s', 'now')),
+            FOREIGN KEY (source_id) REFERENCES kg_entities(id) ON DELETE CASCADE,
+            FOREIGN KEY (target_id) REFERENCES kg_entities(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_deps_source ON kg_dependencies(source_id);
+        CREATE INDEX IF NOT EXISTS idx_deps_target ON kg_dependencies(target_id);
+
+        CREATE TABLE IF NOT EXISTS kg_confidence_log (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            entity_id  INTEGER NOT NULL,
+            old_value  REAL    NOT NULL,
+            new_value  REAL    NOT NULL,
+            reason     TEXT    NOT NULL,
+            created_at INTEGER DEFAULT (strftime('%s', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_conf_log_entity ON kg_confidence_log(entity_id);
+    "#,
+    )?;
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -268,6 +316,8 @@ mod tests {
             "kg_hyperedge_entities",
             "kg_turboquant_cache",
             "kg_schema_version",
+            "kg_dependencies",
+            "kg_confidence_log",
         ];
 
         for table in &tables {
@@ -280,6 +330,56 @@ mod tests {
                 .unwrap();
             assert_eq!(count, 1, "table {table} should exist");
         }
+    }
+
+    #[test]
+    fn test_v3_entity_columns_exist() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        // Verify new v3 columns are writable
+        conn.execute(
+            "INSERT INTO kg_entities \
+             (entity_type, name, confidence, access_count, base_confidence, decay_rate) \
+             VALUES ('test', 'T', 0.9, 5, 0.9, 0.05)",
+            [],
+        )
+        .unwrap();
+
+        let (conf, acc): (f64, i64) = conn
+            .query_row(
+                "SELECT confidence, access_count FROM kg_entities WHERE name = 'T'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!((conf - 0.9).abs() < 1e-9);
+        assert_eq!(acc, 5);
+    }
+
+    #[test]
+    fn test_v3_new_tables_writable() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('a', 'X')",
+            [],
+        )
+        .unwrap();
+        let id: i64 = conn.last_insert_rowid();
+
+        conn.execute(
+            "INSERT INTO kg_confidence_log (entity_id, old_value, new_value, reason) \
+             VALUES (?1, 1.0, 0.8, 'test')",
+            [id],
+        )
+        .unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM kg_confidence_log", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/src/vector/confidence.rs
+++ b/src/vector/confidence.rs
@@ -1,0 +1,245 @@
+//! Ebbinghaus forgetting-curve confidence engine.
+//!
+//! Formula:
+//! ```text
+//! confidence(t) = base * exp(-lambda * elapsed_days)
+//!              + access_bonus * ln(1 + access_count)
+//!              + feedback_sum          // clamped to [-1, 1]
+//! ```
+//! Defaults: lambda = 0.05 / day, access_bonus = 0.1.
+
+use crate::error::{Error, Result};
+use rusqlite::Connection;
+use tracing::debug;
+
+const SECS_PER_DAY: f64 = 86_400.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Tuneable parameters for the confidence formula.
+#[derive(Debug, Clone)]
+pub struct ConfidenceParams {
+    /// Decay rate λ (per day). Default: 0.05.
+    pub lambda: f64,
+    /// Reinforcement factor for access count. Default: 0.1.
+    pub access_bonus: f64,
+}
+
+impl Default for ConfidenceParams {
+    fn default() -> Self {
+        Self {
+            lambda: 0.05,
+            access_bonus: 0.1,
+        }
+    }
+}
+
+/// Implements the Ebbinghaus forgetting-curve confidence formula.
+#[derive(Default)]
+pub struct ConfidenceEngine {
+    pub params: ConfidenceParams,
+}
+
+impl ConfidenceEngine {
+    pub fn new(params: ConfidenceParams) -> Self {
+        Self { params }
+    }
+
+    /// Pure formula evaluation — no database access required.
+    pub fn compute(
+        &self,
+        base: f64,
+        lambda: f64,
+        elapsed_days: f64,
+        access_count: i64,
+        feedback_sum: f64,
+    ) -> f64 {
+        let fb = feedback_sum.clamp(-1.0, 1.0);
+        base * (-lambda * elapsed_days).exp()
+            + self.params.access_bonus * (1.0 + access_count as f64).ln()
+            + fb
+    }
+
+    /// Recompute live confidence from the entity's stored parameters and log.
+    pub fn get_confidence(&self, conn: &Connection, entity_id: i64) -> Result<f64> {
+        let (base, lambda, created_at, access_count) = conn
+            .query_row(
+                "SELECT \
+                    COALESCE(base_confidence, 1.0), \
+                    COALESCE(decay_rate, 0.05), \
+                    COALESCE(created_at, 0), \
+                    COALESCE(access_count, 0) \
+                 FROM kg_entities WHERE id = ?1",
+                [entity_id],
+                |r| {
+                    Ok((
+                        r.get::<_, f64>(0)?,
+                        r.get::<_, f64>(1)?,
+                        r.get::<_, i64>(2)?,
+                        r.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Error::EntityNotFound(entity_id),
+                other => Error::SQLite(other),
+            })?;
+
+        let elapsed_days = (now_unix() - created_at).max(0) as f64 / SECS_PER_DAY;
+        let feedback_sum = feedback_sum_for(conn, entity_id)?;
+        let conf = self.compute(base, lambda, elapsed_days, access_count, feedback_sum);
+
+        debug!(entity_id, elapsed_days, conf, "live confidence computed");
+        Ok(conf)
+    }
+
+    /// Apply an explicit feedback adjustment, log the change, and refresh the cache.
+    pub fn update_confidence(
+        &self,
+        conn: &Connection,
+        entity_id: i64,
+        feedback: f64,
+    ) -> Result<f64> {
+        let old_conf = self.get_confidence(conn, entity_id)?;
+        let ts = now_unix();
+
+        // Log the raw delta: new_value - old_value == feedback.
+        conn.execute(
+            "INSERT INTO kg_confidence_log \
+             (entity_id, old_value, new_value, reason, created_at) \
+             VALUES (?1, ?2, ?3, 'feedback', ?4)",
+            rusqlite::params![entity_id, old_conf, old_conf + feedback, ts],
+        )?;
+
+        // Recompute with the newly inserted feedback included.
+        let new_conf = self.get_confidence(conn, entity_id)?;
+        conn.execute(
+            "UPDATE kg_entities SET confidence = ?1 WHERE id = ?2",
+            rusqlite::params![new_conf, entity_id],
+        )?;
+
+        debug!(
+            entity_id,
+            old_conf, new_conf, feedback, "confidence updated"
+        );
+        Ok(new_conf)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Sum all raw feedback deltas for an entity, clamped to [-1, 1].
+fn feedback_sum_for(conn: &Connection, entity_id: i64) -> Result<f64> {
+    let sum: f64 = conn.query_row(
+        "SELECT COALESCE(SUM(new_value - old_value), 0.0) \
+         FROM kg_confidence_log \
+         WHERE entity_id = ?1 AND reason = 'feedback'",
+        [entity_id],
+        |r| r.get(0),
+    )?;
+    Ok(sum.clamp(-1.0, 1.0))
+}
+
+pub(crate) fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time before Unix epoch")
+        .as_secs() as i64
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::ensure_schema;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        conn
+    }
+
+    fn insert_entity(conn: &Connection, base: f64, lambda: f64) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name, base_confidence, decay_rate) \
+             VALUES ('test', 'E', ?1, ?2)",
+            rusqlite::params![base, lambda],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn fresh_entity_confidence_is_base() {
+        let conn = setup();
+        let id = insert_entity(&conn, 1.0, 0.05);
+        let engine = ConfidenceEngine::default();
+        let conf = engine.get_confidence(&conn, id).unwrap();
+        // elapsed ≈ 0 days, access_count=0, feedback=0 → base * exp(0) = base
+        assert!((conf - 1.0).abs() < 0.01, "expected ~1.0, got {conf}");
+    }
+
+    #[test]
+    fn confidence_decays_over_time() {
+        let engine = ConfidenceEngine::default();
+        let conf_now = engine.compute(1.0, 0.05, 0.0, 0, 0.0);
+        let conf_30d = engine.compute(1.0, 0.05, 30.0, 0, 0.0);
+        assert!(conf_30d < conf_now, "confidence should decay over time");
+        assert!(conf_30d > 0.0, "confidence should stay positive");
+    }
+
+    #[test]
+    fn access_reinforces_confidence() {
+        let engine = ConfidenceEngine::default();
+        let low = engine.compute(1.0, 0.05, 30.0, 0, 0.0);
+        let high = engine.compute(1.0, 0.05, 30.0, 10, 0.0);
+        assert!(high > low, "access should reinforce confidence");
+    }
+
+    #[test]
+    fn feedback_adjusts_confidence() {
+        let conn = setup();
+        let id = insert_entity(&conn, 0.8, 0.0); // no decay
+        let engine = ConfidenceEngine::default();
+
+        // elapsed ≈ 0, access=0, feedback=0 → ~0.8
+        let before = engine.get_confidence(&conn, id).unwrap();
+        assert!((before - 0.8).abs() < 0.01, "expected ~0.8, got {before}");
+
+        let after = engine.update_confidence(&conn, id, -0.2).unwrap();
+        assert!((after - 0.6).abs() < 0.01, "expected ~0.6, got {after}");
+    }
+
+    #[test]
+    fn feedback_sum_bounded() {
+        let engine = ConfidenceEngine::default();
+        // Very negative feedback_sum is clamped to -1.0
+        let c = engine.compute(1.0, 0.0, 0.0, 0, -5.0);
+        // base*1 + 0 + clamp(-5,-1,1) = 1.0 + (-1.0) = 0.0
+        assert!((c - 0.0).abs() < 1e-9, "expected 0.0, got {c}");
+    }
+
+    #[test]
+    fn change_logged_to_confidence_log() {
+        let conn = setup();
+        let id = insert_entity(&conn, 1.0, 0.0);
+        let engine = ConfidenceEngine::default();
+        engine.update_confidence(&conn, id, -0.1).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_confidence_log WHERE entity_id = ?1 AND reason = 'feedback'",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "feedback entry should be logged");
+    }
+}

--- a/src/vector/confidence.rs
+++ b/src/vector/confidence.rs
@@ -64,11 +64,11 @@ impl ConfidenceEngine {
 
     /// Recompute live confidence from the entity's stored parameters and log.
     pub fn get_confidence(&self, conn: &Connection, entity_id: i64) -> Result<f64> {
-        let (base, lambda, created_at, access_count) = conn
+        let (base, stored_lambda, created_at, access_count) = conn
             .query_row(
                 "SELECT \
                     COALESCE(base_confidence, 1.0), \
-                    COALESCE(decay_rate, 0.05), \
+                    decay_rate, \
                     COALESCE(created_at, 0), \
                     COALESCE(access_count, 0) \
                  FROM kg_entities WHERE id = ?1",
@@ -76,7 +76,7 @@ impl ConfidenceEngine {
                 |r| {
                     Ok((
                         r.get::<_, f64>(0)?,
-                        r.get::<_, f64>(1)?,
+                        r.get::<_, Option<f64>>(1)?,
                         r.get::<_, i64>(2)?,
                         r.get::<_, i64>(3)?,
                     ))
@@ -86,6 +86,7 @@ impl ConfidenceEngine {
                 rusqlite::Error::QueryReturnedNoRows => Error::EntityNotFound(entity_id),
                 other => Error::SQLite(other),
             })?;
+        let lambda = stored_lambda.unwrap_or(self.params.lambda);
 
         let elapsed_days = (now_unix() - created_at).max(0) as f64 / SECS_PER_DAY;
         let feedback_sum = feedback_sum_for(conn, entity_id)?;
@@ -105,20 +106,32 @@ impl ConfidenceEngine {
         let old_conf = self.get_confidence(conn, entity_id)?;
         let ts = now_unix();
 
-        // Log the raw delta: new_value - old_value == feedback.
-        conn.execute(
+        let tx = conn.unchecked_transaction()?;
+
+        // Insert with raw delta as placeholder so feedback_sum_for picks it up.
+        tx.execute(
             "INSERT INTO kg_confidence_log \
              (entity_id, old_value, new_value, reason, created_at) \
              VALUES (?1, ?2, ?3, 'feedback', ?4)",
             rusqlite::params![entity_id, old_conf, old_conf + feedback, ts],
         )?;
+        let log_rowid = tx.last_insert_rowid();
 
         // Recompute with the newly inserted feedback included.
-        let new_conf = self.get_confidence(conn, entity_id)?;
-        conn.execute(
+        let new_conf = self.get_confidence(&tx, entity_id)?;
+
+        // Correct the log entry to show the actual resulting confidence.
+        tx.execute(
+            "UPDATE kg_confidence_log SET new_value = ?1 WHERE rowid = ?2",
+            rusqlite::params![new_conf, log_rowid],
+        )?;
+
+        tx.execute(
             "UPDATE kg_entities SET confidence = ?1 WHERE id = ?2",
             rusqlite::params![new_conf, entity_id],
         )?;
+
+        tx.commit()?;
 
         debug!(
             entity_id,

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,8 +1,10 @@
 //! Vector module for semantic search with cosine similarity and TurboQuant indexing.
 
+pub mod confidence;
 pub mod store;
 pub mod turboquant;
 
+pub use confidence::{ConfidenceEngine, ConfidenceParams};
 pub use store::{cosine_similarity, SearchResult, VectorStore};
 pub use turboquant::{
     LinearScanIndex, LinearScanStats, TurboQuantConfig, TurboQuantIndex, TurboQuantStats,


### PR DESCRIPTION
Based on SmartVector paper, adds temporal awareness, confidence decay, and relational dependency tracking to the knowledge graph.

Schema migration v3:
- kg_entities: confidence, access_count, last_accessed, valid_from, valid_until, base_confidence, decay_rate
- kg_relations: confidence, valid_from, valid_until
- kg_dependencies: entity dependency edges (depends_on, supersedes, etc.)
- kg_confidence_log: confidence change history

New modules:
- vector/confidence.rs: Ebbinghaus forgetting-curve ConfidenceEngine
- graph/ripple.rs: BFS ripple propagation with hop-attenuated penalties
- rag/smart_retrieval.rs: four-signal retrieval scoring (cosine + temporal + confidence + graph importance)

Bug fixes:
- get_entity: handle NULL properties column
- KnowledgeGraph constructors: initialize retrieval_weights field

OpenSpec: openspec/smartvector.spec.md
Tests: 132 passed, 0 failed

## 变更说明
<!-- 描述这个 PR 做了什么，解决了什么问题 -->

## 变更类型
- [ ] `feat`: 新功能
- [ ] `fix`: Bug 修复
- [ ] `chore`: 依赖/配置/格式变更
- [ ] `docs`: 文档更新
- [ ] `refactor`: 重构（无功能变化）

## 测试
- [ ] `cargo test` 通过
- [ ] `cargo clippy -- -D warnings` 通过
- [ ] `cargo fmt -- --check` 通过

## 备注
<!-- 其他需要 reviewer 了解的信息 -->
