### PR TITLE
feat: QuaQue knowledge-graph versioning (arXiv:2603.18654)

### DIFF
--- a/openspec/changes/quaque-versioning/.openspec.yaml
+++ b/openspec/changes/quaque-versioning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/quaque-versioning/design.md
+++ b/openspec/changes/quaque-versioning/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The sqlite-knowledge-graph library (schema v3) stores entities, relations, vectors, and hyperedges in SQLite. There is no versioning — the graph is a single mutable state. The QuaQue paper (arXiv:2603.18654) describes a condensed relational model where each row carries a bitstring column (`validity`) whose Nth bit indicates the row belongs to version N. Version filtering becomes bitwise AND, version merging becomes bitwise OR/AND — all O(1) per row with no data duplication.
+
+Our property graph differs from RDF quads (entities have mutable properties, relations have weights), but the bitstring existence-tracking maps cleanly to snapshot semantics: a version captures *which* entities and relations exist, not their property values at that point in time.
+
+Current schema: `kg_entities`, `kg_relations`, `kg_vectors`, `kg_hyperedges`, `kg_hyperedge_entities`, `kg_turboquant_cache`, `kg_schema_version`, `kg_dependencies`, `kg_confidence_log`. Migration system is at v3 with `ensure_schema()` auto-migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Snapshot the KG at named version points
+- Query the graph as it existed at a specific version
+- Compare two versions (added/removed entities and relations)
+- Merge versions with union or intersection strategy
+- Support branching via parent_id lineage
+- Full backward compatibility — existing code and databases work unchanged
+
+**Non-Goals:**
+- Property-level change tracking across versions (bitstring tracks existence only)
+- Version-aware vectors, hyperedges, or algorithms (PageRank, Louvain — these operate on the full graph)
+- More than 64 concurrent versions (SQLite INTEGER is 64-bit signed)
+- Conflict resolution beyond union/intersection
+- Auto-versioning on every write
+
+## Decisions
+
+### 1. Opt-in domain module vs versioned core
+
+**Decision**: New `src/version/` module with `version_*` methods on `KnowledgeGraph`. Existing API untouched.
+
+**Rationale**: The library has ~30 public methods. Adding an optional `version_id` parameter to every one would be a breaking change and bloat signatures for callers who don't need versioning. A separate domain module follows the existing pattern (algorithms, vector, rag are all domain modules).
+
+**Alternative considered**: Version parameter on every function. Rejected — too invasive, and algorithms like PageRank don't have a meaningful per-version scope.
+
+### 2. NULL validity = unversioned, visible everywhere
+
+**Decision**: `validity INTEGER DEFAULT NULL`. NULL means "not participating in versioning, visible in all queries". Non-NULL bitstring means "exists only in these versions".
+
+**Rationale**: Backward compatibility. Existing rows get NULL after migration v4. Existing queries (no version filter) return everything. Only version-aware queries use the bitstring.
+
+**Key SQL pattern**: `COALESCE(validity, 0) | (1 << bit)` handles first-time assignment from NULL.
+
+### 3. SQLite INTEGER for bitstring (64 *concurrent* versions)
+
+**Decision**: Use native SQLite INTEGER (signed 64-bit). No BLOB fallback. The limit is 64 *concurrent* live versions; slots are reclaimed on delete (see Decision 4).
+
+**Rationale**: 64 concurrent versions is generous for snapshot use cases. INTEGER supports native bitwise operators (`&`, `|`, `~`, `<<`). No custom BLOB functions needed. If the limit is ever hit, `create_version` returns `Error::VersionLimitExceeded` (a clean, recoverable error — never a panic or silent corruption). Raising the ceiling would require a schema redesign (new migration to BLOB + custom functions).
+
+### 4. Version bit position = a reclaimable `bit_slot`, not the auto-increment id
+
+**Decision**: Each `kg_versions` row carries a `bit_slot` column in `[0, 63]` (`UNIQUE`), assigned as the lowest free slot at creation and freed on deletion. The validity bit is `1 << bit_slot`.
+
+**Rationale**: An earlier draft used `1 << (version_id - 1)`. Because `version_id` comes from `AUTOINCREMENT` and is never reused, that made the limit "64 version *creations* over the database lifetime" and, worse, the 65th creation computed `1 << 64` — a panic in debug builds and a silent bit-aliasing corruption in release. Decoupling the bit position into a reclaimable slot makes the limit exactly 64 *concurrent* versions and removes the overflow entirely (`bit_from_slot` always shifts by 0–63). Deleting a version clears its bit from every entity/relation row in the same transaction, so a recycled slot can never inherit stale membership.
+
+### 5. bit_count via custom scalar function (registered on both surfaces)
+
+**Decision**: Register `kg_bit_count(x)` using `x.count_ones()`, NULL → 0.
+
+**Rationale**: SQLite has no built-in `bit_count()`. Needed for version-aware aggregation (e.g., "how many versions does this entity span"). It is registered in **two** places, because the library and the loadable extension use different registration paths: `functions::register_functions` (rusqlite path, used by `KnowledgeGraph::open*`) and `extension::register_extension_functions` (sqlite-loadable path, used by the `cdylib` `.load` entry point). Both must register it for raw-SQL availability on both surfaces.
+
+### 6. Merge creates a new version row (atomically)
+
+**Decision**: `version_merge(source_ids, target_name, strategy)` creates a new `kg_versions` row and updates validity columns on entities/relations using bitwise OR. Union sets the new bit where `(validity & source_mask) != 0`; intersection where `(validity & source_mask) = source_mask`. The whole operation — new version, `is_merged` flag, and both UPDATEs — runs in a single transaction.
+
+**Rationale**: Non-destructive — source versions remain unchanged. The new version gets its own slot. Wrapping in a transaction means a mid-merge failure leaves no half-built version. The intersection predicate is a single set-based UPDATE rather than a per-row loop.
+
+## Risks / Trade-offs
+
+- **[64-version limit]** → Document clearly. For a snapshot tool this is generous. If hit, requires BLOB migration — a separate future change.
+- **[NULL vs 0 ambiguity]** → Document convention: NULL = unversioned, 0 = "in versioning but in no version" (shouldn't occur). `version_remove_entity` should check if result would be 0 and either leave it or set NULL.
+- **[Existing queries ignore versions]** → This is by design (backward compat). But it means a user querying raw SQL won't see version filtering unless they add WHERE clauses. Document the pattern.
+- **[No property history]** → Explicitly out of scope. If users need it later, a `kg_entity_property_history` table can be added without changing the bitstring design.
+- **[Migration v4 is non-destructive]** → ALTER TABLE ADD COLUMN is safe. No data loss possible. `validity=NULL` for all existing rows.

--- a/openspec/changes/quaque-versioning/proposal.md
+++ b/openspec/changes/quaque-versioning/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The knowledge graph has no versioning — once an entity or relation is created, there is no way to snapshot the graph state, compare snapshots, or branch/merge. This makes it impossible to track how the KG evolves over time, compare two research snapshots, or roll back to a known-good state. The QuaQue paper (arXiv:2603.18654) describes a condensed relational model where a single bitstring column tracks which versions a row belongs to, enabling fast bitwise version filtering without duplicating data. This maps directly to our SQLite property graph.
+
+## What Changes
+
+- Add a `kg_versions` table to track version metadata (name, branch, parent, timestamps, and a reclaimable `bit_slot`)
+- Add a `validity INTEGER DEFAULT NULL` column to `kg_entities` and `kg_relations` — a 64-bit bitstring where the bit at a version's `bit_slot` is set when the row exists in that version
+- Add a new `src/version/` domain module with version CRUD, snapshot, query, diff, and merge operations
+- Register a `kg_bit_count()` SQLite custom function for version-aware aggregation queries
+- Add ~15 new methods to `KnowledgeGraph` (prefixed `version_`) — existing API is unchanged
+- Migration v4 in the existing schema versioning system
+
+## Capabilities
+
+### New Capabilities
+
+- `version-store`: Version lifecycle — create, delete, list versions with branch/parent tracking. The `kg_versions` table and CRUD operations.
+- `version-snapshot`: Assigning entities/relations to versions via bitstring manipulation (add/remove from version, bulk snapshot, COALESCE-based NULL handling for backward compat).
+- `version-query`: Version-filtered queries — get entities/relations for a specific version, version-aware neighbor traversal, version-aware graph stats. Uses `(validity & (1 << bit)) != 0` filtering.
+- `version-diff`: Comparing two versions — added/removed entities and relations. Bitwise intersection/exclusion to compute diffs efficiently.
+- `version-merge`: Merging versions with union or intersection strategy. Branching via parent_id. Bitwise OR/AND operations on validity columns.
+
+### Modified Capabilities
+
+(None — all version functionality is additive. Existing API signatures are unchanged.)
+
+## Impact
+
+- **Schema**: Migration v4 adds one table (`kg_versions`, including a `bit_slot INTEGER NOT NULL UNIQUE`) and two columns (`validity` on `kg_entities`, `kg_relations`). Non-destructive — existing rows get `validity=NULL`.
+- **New module**: `src/version/` with ~5 files (mod.rs, store.rs, snapshot.rs, query.rs, diff.rs, merge.rs)
+- **Functions**: `src/functions.rs` gains `kg_bit_count()` registration (rusqlite path)
+- **Public API**: `KnowledgeGraph` gains ~15 new `version_*` methods. `lib.rs` re-exports new types. New error variant `VersionLimitExceeded`.
+- **Schema version**: `CURRENT_SCHEMA_VERSION` bumps from 3 to 4
+- **Dependencies**: No new crate dependencies — uses existing `rusqlite` for bitwise SQL operations
+- **SQLite extension**: The `cdylib` build registers `kg_bit_count` explicitly in `extension::register_extension_functions` (the loadable-extension path; the rusqlite `register_functions` registration does not apply to `.load`-ed connections)

--- a/openspec/changes/quaque-versioning/specs/version-diff/spec.md
+++ b/openspec/changes/quaque-versioning/specs/version-diff/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Compare two versions
+The system SHALL compare two versions and return entities and relations that were added, removed, or common between them.
+
+#### Scenario: Entities added in newer version
+- **WHEN** version 1 has entities {A, B} and version 2 has entities {A, B, C}
+- **AND** `version_compare` is called with v1=1, v2=2
+- **THEN** the result includes `added_entities: [C]`, `removed_entities: []`, `common_entities: [A, B]`
+
+#### Scenario: Entities removed in newer version
+- **WHEN** version 1 has entities {A, B, C} and version 2 has entities {A, B}
+- **AND** `version_compare` is called with v1=1, v2=2
+- **THEN** the result includes `removed_entities: [C]`, `added_entities: []`
+
+#### Scenario: Relations diff
+- **WHEN** version 1 has relation R1 (A→B) and version 2 has relations R1 (A→B), R2 (B→C)
+- **AND** `version_compare` is called with v1=1, v2=2
+- **THEN** the result includes `added_relations: [R2]`, `removed_relations: []`, `common_relations: [R1]`
+
+### Requirement: Version diff result structure
+The system SHALL expose a `VersionDiff` struct with fields: `added_entities` (Vec<Entity>), `removed_entities` (Vec<Entity>), `common_entities` (Vec<Entity>), `added_relations` (Vec<Relation>), `removed_relations` (Vec<Relation>), `common_relations` (Vec<Relation>).
+
+#### Scenario: Diff result is complete
+- **WHEN** a diff is computed between two versions with different entity/relation sets
+- **THEN** every entity and relation across both versions appears in exactly one of: added, removed, or common
+
+### Requirement: Entity version history
+The system SHALL return a list of all versions that contain a given entity.
+
+#### Scenario: Entity exists in multiple versions
+- **WHEN** entity has validity=0b101 (in versions 1 and 3)
+- **AND** `version_entity_history` is called with that entity_id
+- **THEN** the result is a list of Version structs for versions 1 and 3
+
+#### Scenario: Unversioned entity
+- **WHEN** entity has validity=NULL
+- **AND** `version_entity_history` is called
+- **THEN** the result is an empty list

--- a/openspec/changes/quaque-versioning/specs/version-merge/spec.md
+++ b/openspec/changes/quaque-versioning/specs/version-merge/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Merge versions with union strategy
+The system SHALL create a new version that is the union of two or more source versions. For each entity/relation, if it exists in ANY source version, its validity bit for the new version SHALL be set.
+
+#### Scenario: Union merge of two versions
+- **WHEN** version 1 has entities {A, B} and version 2 has entities {B, C}
+- **AND** `version_merge` is called with source_ids=[1,2], name="merged", strategy="union"
+- **THEN** a new version 3 is created, and entities {A, B, C} all have bit 2 set in their validity
+
+#### Scenario: Union merge of relations
+- **WHEN** version 1 has relation R1 and version 2 has relations R1, R2
+- **AND** union merge is performed
+- **THEN** both R1 and R2 have the new version's bit set
+
+### Requirement: Merge versions with intersection strategy
+The system SHALL create a new version that is the intersection of two or more source versions. For each entity/relation, if it exists in ALL source versions, its validity bit for the new version SHALL be set.
+
+#### Scenario: Intersection merge
+- **WHEN** version 1 has entities {A, B, C} and version 2 has entities {B, C, D}
+- **AND** `version_merge` is called with source_ids=[1,2], strategy="intersection"
+- **THEN** a new version is created, and only entities {B, C} have the new version's bit set
+
+### Requirement: Merge creates a new version row
+The system SHALL create a new `kg_versions` row for the merged version. The `parent_id` of the merged version SHALL be set to the first source version's ID.
+
+#### Scenario: Merge version metadata
+- **WHEN** merge is called with source_ids=[1,2], name="merge-1-2"
+- **THEN** a new kg_versions row is created with name="merge-1-2", parent_id=1, is_merged=1
+
+### Requirement: Branch support via parent_id
+The system SHALL support branching by creating a version with a parent_id that differs from the current branch. This establishes lineage but does not copy data — the new version starts empty.
+
+#### Scenario: Create branch version
+- **WHEN** `create_version` is called with name="feature-branch-v1", branch="feature", parent_id=5
+- **THEN** a new version is created on branch "feature" with parent_id=5, and the version starts with no entities/relations assigned
+
+### Requirement: Invalid merge detection
+The system SHALL reject a merge with fewer than 2 source versions.
+
+#### Scenario: Merge with one source
+- **WHEN** `version_merge` is called with source_ids=[1]
+- **THEN** the system SHALL return an error
+
+#### Scenario: Merge with non-existent version
+- **WHEN** `version_merge` is called with source_ids=[1, 999]
+- **THEN** the system SHALL return an error

--- a/openspec/changes/quaque-versioning/specs/version-query/spec.md
+++ b/openspec/changes/quaque-versioning/specs/version-query/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Get entities for a version
+The system SHALL return all entities whose validity bitstring has the bit set for the given version. Entities with validity=NULL SHALL be excluded from version-filtered queries.
+
+#### Scenario: Query entities in a specific version
+- **WHEN** `version_entities` is called with version_id=2 and entities {A: validity=0b11, B: validity=0b01, C: validity=NULL} exist
+- **THEN** only entity A is returned (bit 1 set = version 2)
+
+#### Scenario: Query entities with type filter
+- **WHEN** `version_entities` is called with version_id=1 and entity_type="paper"
+- **THEN** only entities of type "paper" with bit 0 set in validity are returned
+
+### Requirement: Get relations for a version
+The system SHALL return all relations whose validity bitstring has the bit set for the given version.
+
+#### Scenario: Query relations in a specific version
+- **WHEN** `version_relations` is called with version_id=1
+- **THEN** only relations with `(validity & 1) != 0` are returned
+
+#### Scenario: Filter relations by type in a version
+- **WHEN** `version_relations` is called with version_id=1 and rel_type="cites"
+- **THEN** only "cites" relations with bit 0 set are returned
+
+### Requirement: Version-aware neighbor traversal
+The system SHALL return neighbors of an entity filtered to a specific version — both the entity and the connecting relation MUST exist in that version.
+
+#### Scenario: Get neighbors in version
+- **WHEN** entity A (validity=0b11) has relations to B (relation validity=0b01) and C (relation validity=0b10)
+- **AND** `version_neighbors` is called with entity A, version_id=1, depth=1
+- **THEN** only neighbor B is returned (relation to B exists in version 1, relation to C does not)
+
+#### Scenario: Neighbor entity not in version
+- **WHEN** entity A (validity=0b11) has a relation to B (validity=0b10) via relation (validity=0b11)
+- **AND** `version_neighbors` is called with version_id=1
+- **THEN** B is excluded because B's validity bit 0 is not set (B doesn't exist in version 1)
+
+### Requirement: Register kg_bit_count SQL function
+The system SHALL register a `kg_bit_count(x)` SQLite scalar function that returns the population count of the integer argument, treating NULL as 0. It MUST be registered on both function surfaces: the rusqlite path (`functions::register_functions`, used by `KnowledgeGraph::open*`) and the loadable-extension path (`extension::register_extension_functions`, used by the `cdylib` `.load` entry point), so raw SQL can call it on either kind of connection.
+
+#### Scenario: kg_bit_count available on a library connection
+- **WHEN** SQL `SELECT kg_bit_count(7)` is executed on a `KnowledgeGraph` connection (7 = 0b111)
+- **THEN** the result is 3
+
+#### Scenario: kg_bit_count available in the loadable extension
+- **WHEN** the compiled `cdylib` is `.load`-ed and `SELECT kg_bit_count(7)` is executed
+- **THEN** the result is 3
+
+#### Scenario: kg_bit_count with zero
+- **WHEN** SQL `SELECT kg_bit_count(0)` is executed
+- **THEN** the result is 0
+
+#### Scenario: kg_bit_count with NULL
+- **WHEN** SQL `SELECT kg_bit_count(NULL)` is executed
+- **THEN** the result is 0

--- a/openspec/changes/quaque-versioning/specs/version-snapshot/spec.md
+++ b/openspec/changes/quaque-versioning/specs/version-snapshot/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Add entity to version
+The system SHALL set the bit corresponding to a version in an entity's validity bitstring. If the entity's validity is NULL (unversioned), it SHALL be initialized to the version's bit using COALESCE.
+
+#### Scenario: Add unversioned entity to first version
+- **WHEN** entity has validity=NULL and `version_add_entity` is called with version_id=1
+- **THEN** the entity's validity is set to `1 << 0` (0b1)
+
+#### Scenario: Add entity to additional version
+- **WHEN** entity has validity=0b01 (in version 1) and `version_add_entity` is called with version_id=2
+- **THEN** the entity's validity is updated to 0b11 (in versions 1 and 2)
+
+#### Scenario: Add to non-existent entity
+- **WHEN** `version_add_entity` is called with an entity_id that does not exist
+- **THEN** the system SHALL return an error
+
+#### Scenario: Add to non-existent version
+- **WHEN** `version_add_entity` is called with a version_id that does not exist
+- **THEN** the system SHALL return an error
+
+### Requirement: Remove entity from version
+The system SHALL clear the bit corresponding to a version in an entity's validity bitstring. If the result would be 0, validity SHALL be set to NULL (returning to unversioned state).
+
+#### Scenario: Remove entity from one of multiple versions
+- **WHEN** entity has validity=0b11 (in versions 1,2) and `version_remove_entity` is called with version_id=1
+- **THEN** the entity's validity becomes 0b10 (in version 2 only)
+
+#### Scenario: Remove entity from its only version
+- **WHEN** entity has validity=0b01 (in version 1 only) and `version_remove_entity` is called with version_id=1
+- **THEN** the entity's validity is set to NULL (unversioned)
+
+### Requirement: Add relation to version
+The system SHALL set the bit corresponding to a version in a relation's validity bitstring, with the same NULL-handling semantics as entity.
+
+#### Scenario: Add relation to version
+- **WHEN** relation has validity=NULL and `version_add_relation` is called with version_id=1
+- **THEN** the relation's validity is set to `1 << 0`
+
+### Requirement: Remove relation from version
+The system SHALL clear the bit corresponding to a version in a relation's validity bitstring, with the same zero-to-NULL semantics as entity.
+
+#### Scenario: Remove relation from version
+- **WHEN** relation has validity=0b11 and `version_remove_relation` is called with version_id=1
+- **THEN** the relation's validity becomes 0b10
+
+### Requirement: Bulk snapshot
+The system SHALL support adding all current entities and/or relations to a version in a single transactional operation.
+
+#### Scenario: Snapshot all entities into a version
+- **WHEN** `version_snapshot_entities` is called with version_id=1
+- **THEN** all entities with validity=NULL have their validity set to `1 << 0`, and all entities already in versioning have the bit OR'd in, within a single transaction

--- a/openspec/changes/quaque-versioning/specs/version-store/spec.md
+++ b/openspec/changes/quaque-versioning/specs/version-store/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Create a named version
+The system SHALL create a new version with a unique name, optional branch label, optional parent version, and optional description. The version ID SHALL be auto-incremented and returned to the caller.
+
+#### Scenario: Create a version with all fields
+- **WHEN** `create_version` is called with name="v1", branch="main", parent_id=None, description="initial snapshot"
+- **THEN** a new row is inserted into `kg_versions` with those values, `is_merged=0`, `created_at` set to current unix timestamp, and the new version ID is returned
+
+#### Scenario: Create a version with defaults
+- **WHEN** `create_version` is called with name="v2" and no other arguments
+- **THEN** a new row is inserted with branch="main", parent_id=NULL, description=NULL, is_merged=0
+
+#### Scenario: Duplicate version name rejected
+- **WHEN** `create_version` is called with a name that already exists in `kg_versions`
+- **THEN** the system SHALL return an error
+
+### Requirement: Delete a version
+The system SHALL delete a version by ID. In a single transaction it SHALL clear that version's bit from the validity bitstring of every entity and relation, then remove the `kg_versions` row, freeing the version's `bit_slot` for reuse. Clearing a bit that leaves a validity of 0 SHALL collapse it back to NULL (the unversioned sentinel).
+
+#### Scenario: Delete an existing version clears its bit
+- **WHEN** `delete_version` is called with a valid version ID
+- **THEN** the row is removed from `kg_versions`, the version's bit is cleared from all entity/relation validity bitstrings in the same transaction, and any row left with validity 0 is set to NULL
+
+#### Scenario: Delete a non-existent version
+- **WHEN** `delete_version` is called with an ID that does not exist
+- **THEN** the system SHALL return `VersionNotFound`
+
+### Requirement: Bit-slot allocation and concurrency limit
+Each version SHALL own a `bit_slot` in the range `[0, 63]` that determines its bit position in the validity bitstring (`1 << bit_slot`). The system SHALL assign the lowest free slot at creation, drawn from slots not held by any live version, so that a slot freed by [Delete a version](#requirement-delete-a-version) is reused. The system SHALL support up to 64 concurrent versions.
+
+#### Scenario: First version uses slot 0
+- **WHEN** `create_version` is called on a database with no versions
+- **THEN** the version is assigned `bit_slot=0` and its validity bit is `1 << 0`
+
+#### Scenario: Slot reused after delete without leaking membership
+- **WHEN** a version holding slot 0 (with member entities/relations) is deleted and a new version is created
+- **THEN** the new version is assigned slot 0, and no entity or relation appears in the new version (the deleted version's bits were cleared on delete)
+
+#### Scenario: Version limit exceeded
+- **WHEN** `create_version` is called while all 64 slots are held by live versions
+- **THEN** the system SHALL return `VersionLimitExceeded` (never panic or silently reuse a bit)
+
+### Requirement: List versions
+The system SHALL list all versions, optionally filtered by branch name.
+
+#### Scenario: List all versions
+- **WHEN** `list_versions` is called with no branch filter
+- **THEN** all rows from `kg_versions` are returned, ordered by created_at descending
+
+#### Scenario: List versions by branch
+- **WHEN** `list_versions` is called with branch="feature-x"
+- **THEN** only versions with branch="feature-x" are returned
+
+### Requirement: Version struct
+The system SHALL expose a `Version` struct with fields: `id` (i64), `name` (String), `branch` (String), `parent_id` (Option<i64>), `description` (Option<String>), `created_at` (Option<i64>), `is_merged` (bool).

--- a/openspec/changes/quaque-versioning/tasks.md
+++ b/openspec/changes/quaque-versioning/tasks.md
@@ -1,0 +1,58 @@
+## 1. Schema & Foundation
+
+- [x] 1.1 Add migration v4 to `src/schema.rs`: create `kg_versions` table (id, name UNIQUE, branch, parent_id, description, created_at, is_merged) with indexes on branch and parent_id
+- [x] 1.2 Add `validity INTEGER DEFAULT NULL` column to `kg_entities` and `kg_relations` in migration v4
+- [x] 1.3 Bump `CURRENT_SCHEMA_VERSION` from 3 to 4
+- [x] 1.4 Add schema v4 tests: fresh DB reaches v4, legacy DB migrates, new columns writable, kg_versions table exists
+
+## 2. Version Store
+
+- [x] 2.1 Create `src/version/mod.rs` with `Version` struct (id, name, branch, parent_id, description, created_at, is_merged) and public re-exports
+- [x] 2.2 Create `src/version/store.rs` with `create_version`, `delete_version`, `list_versions` functions
+- [x] 2.3 Add `version_create`, `version_delete`, `version_list` methods to `KnowledgeGraph` in `src/lib.rs`
+- [x] 2.4 Register `version` module in `src/lib.rs` and add re-exports for `Version`
+- [x] 2.5 Add tests for version CRUD: create, duplicate name rejection, delete, delete non-existent, list all, list by branch
+
+## 3. Bitwise Function
+
+- [x] 3.1 Add `kg_bit_count(x)` scalar function to `src/functions.rs` using `x.count_ones()`, handling NULL → 0
+- [x] 3.2 Add tests for kg_bit_count: positive integer, zero, NULL
+
+## 4. Version Snapshot
+
+- [x] 4.1 Create `src/version/snapshot.rs` with `version_add_entity`, `version_remove_entity`, `version_add_relation`, `version_remove_relation`
+- [x] 4.2 Implement NULL → bitstring handling via `COALESCE(validity, 0) | (1 << bit)` and zero-to-NULL on removal
+- [x] 4.3 Implement `version_snapshot_entities` (bulk add all entities to a version in one transaction)
+- [x] 4.4 Add corresponding `version_*` methods to `KnowledgeGraph`
+- [x] 4.5 Add tests: add unversioned entity to version, add to additional version, remove from version, remove from only version (→ NULL), bulk snapshot, error on non-existent entity/version
+
+## 5. Version Query
+
+- [x] 5.1 Create `src/version/query.rs` with `version_entities` and `version_relations` — filtered by `(validity & (1 << bit)) != 0`, excluding NULL
+- [x] 5.2 Implement `version_neighbors` — BFS traversal where both entity and connecting relation must exist in the version
+- [x] 5.3 Add corresponding `version_*` methods to `KnowledgeGraph`
+- [x] 5.4 Add tests: entities in version, entities with type filter, relations in version, relations with rel_type filter, neighbors filtered by version, neighbor entity excluded when not in version
+
+## 6. Version Diff
+
+- [x] 6.1 Create `src/version/diff.rs` with `VersionDiff` struct (added/removed/common entities and relations)
+- [x] 6.2 Implement `version_compare` — compute added/removed/common using bitwise checks per entity and relation
+- [x] 6.3 Implement `version_entity_history` — return all versions containing a given entity
+- [x] 6.4 Add corresponding methods to `KnowledgeGraph` and re-export `VersionDiff`
+- [x] 6.5 Add tests: added entities, removed entities, common entities, relations diff, entity history for multi-version entity, entity history for unversioned entity
+
+## 7. Version Merge
+
+- [x] 7.1 Create `src/version/merge.rs` with `version_merge` function accepting source_ids, target_name, and strategy (union|intersection)
+- [x] 7.2 Implement union merge: create new version, set bit for entities/relations present in ANY source version (bitwise OR)
+- [x] 7.3 Implement intersection merge: create new version, set bit only for entities/relations present in ALL source versions (bitwise AND)
+- [x] 7.4 Add validation: reject < 2 source versions, reject non-existent version IDs
+- [x] 7.5 Add corresponding method to `KnowledgeGraph`
+- [x] 7.6 Add tests: union merge of two versions, intersection merge, merge creates new version row (parent_id, is_merged=1), invalid merge detection
+
+## 8. Integration & Polish
+
+- [x] 8.1 Run `cargo test` — all existing tests pass (no regressions)
+- [x] 8.2 Run `cargo clippy -- -D warnings` — zero warnings
+- [x] 8.3 Run `cargo fmt` — zero diff
+- [x] 8.4 Verify `cargo test --features async` passes (if async feature is used)

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum Error {
     #[error("Version limit exceeded: all 64 version slots are in use")]
     VersionLimitExceeded,
 
+    #[error("Corrupt version data: version {version_id} has out-of-range bit_slot {slot} (expected 0..=63)")]
+    CorruptBitSlot { version_id: i64, slot: i64 },
+
     #[error("Invalid entity type: {0}")]
     InvalidEntityType(String),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,18 @@ pub enum Error {
     #[error("Hyperedge not found: {0}")]
     HyperedgeNotFound(i64),
 
+    #[error("Version not found: {0}")]
+    VersionNotFound(i64),
+
+    #[error("Duplicate version name: {0}")]
+    DuplicateVersionName(String),
+
+    #[error("Invalid merge: {0}")]
+    InvalidMerge(String),
+
+    #[error("Version limit exceeded: all 64 version slots are in use")]
+    VersionLimitExceeded,
+
     #[error("Invalid entity type: {0}")]
     InvalidEntityType(String),
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -7,6 +7,13 @@ use sqlite_loadable::{
 };
 use std::ffi::CString;
 
+/// Helper function to return an integer result
+fn result_int64(context: *mut sqlite3_context, value: i64) {
+    unsafe {
+        sqlite_loadable::ext::sqlite3ext_result_int64(context, value);
+    }
+}
+
 /// Helper function to return text result
 fn result_text(context: *mut sqlite3_context, text: &str) {
     let cstr = CString::new(text).unwrap();
@@ -157,6 +164,23 @@ pub fn kg_connected_components(
     Ok(())
 }
 
+/// kg_bit_count() - Population count of a version validity bitstring
+/// Parameter: x (INTEGER, NULL treated as 0)
+/// Returns the number of set bits (how many versions a row belongs to)
+pub fn kg_bit_count(
+    context: *mut sqlite3_context,
+    values: &[*mut sqlite3_value],
+) -> Result<(), Error> {
+    if values.is_empty() {
+        return Err(Error::new_message("kg_bit_count requires 1 argument"));
+    }
+    // A SQL NULL reads back as 0 here, which has zero set bits — matching the
+    // rusqlite registration's NULL → 0 behavior in src/functions.rs.
+    let val = unsafe { sqlite_loadable::ext::sqlite3ext_value_int64(values[0]) };
+    result_int64(context, val.count_ones() as i64);
+    Ok(())
+}
+
 /// Register functions
 fn register_extension_functions(db: *mut sqlite3) -> Result<(), Error> {
     let flags = FunctionFlags::UTF8 | FunctionFlags::DETERMINISTIC;
@@ -164,6 +188,9 @@ fn register_extension_functions(db: *mut sqlite3) -> Result<(), Error> {
     // Basic info functions
     define_scalar_function(db, "kg_version", 0, kg_version, flags)?;
     define_scalar_function(db, "kg_stats", 0, kg_stats, flags)?;
+
+    // Version bitstring helper (QuaQue versioning)
+    define_scalar_function(db, "kg_bit_count", 1, kg_bit_count, flags)?;
 
     // Graph algorithm functions with optional parameters
     define_scalar_function(db, "kg_pagerank", 0, kg_pagerank, flags)?;

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -59,6 +59,20 @@ pub fn register_functions(conn: &rusqlite::Connection) -> Result<()> {
         },
     )?;
 
+    // Register kg_bit_count — population count for version validity bitstrings.
+    conn.create_scalar_function(
+        "kg_bit_count",
+        1,
+        rusqlite::functions::FunctionFlags::SQLITE_UTF8,
+        |ctx| {
+            let val: Option<i64> = ctx.get(0)?;
+            match val {
+                Some(x) => Ok(x.count_ones() as i64),
+                None => Ok(0),
+            }
+        },
+    )?;
+
     Ok(())
 }
 
@@ -90,5 +104,41 @@ mod tests {
             )
             .unwrap();
         assert!((sim - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_kg_bit_count_positive() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        register_functions(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT kg_bit_count(7)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 3); // 0b111
+    }
+
+    #[test]
+    fn test_kg_bit_count_zero() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        register_functions(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT kg_bit_count(0)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_kg_bit_count_null() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        register_functions(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT kg_bit_count(NULL)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/src/graph/entity.rs
+++ b/src/graph/entity.rs
@@ -82,24 +82,55 @@ pub fn get_entity(conn: &rusqlite::Connection, id: i64) -> Result<Entity> {
         "#,
     )?;
 
-    let entity = stmt.query_row(params![id], |row| {
-        let properties_json: Option<String> = row.get(3)?;
-        let properties: HashMap<String, serde_json::Value> = match properties_json {
-            Some(json) => serde_json::from_str(&json).unwrap_or_default(),
-            None => HashMap::new(),
-        };
-
-        Ok(Entity {
-            id: Some(row.get(0)?),
-            entity_type: row.get(1)?,
-            name: row.get(2)?,
-            properties,
-            created_at: row.get(4)?,
-            updated_at: row.get(5)?,
-        })
-    })?;
-
+    let entity = stmt.query_row(params![id], row_to_entity)?;
     Ok(entity)
+}
+
+/// Map a `kg_entities` row (id, entity_type, name, properties, created_at,
+/// updated_at) to an [`Entity`]. Shared by all entity read paths.
+fn row_to_entity(row: &rusqlite::Row) -> rusqlite::Result<Entity> {
+    let properties_json: Option<String> = row.get(3)?;
+    let properties: HashMap<String, serde_json::Value> = match properties_json {
+        Some(json) => serde_json::from_str(&json).unwrap_or_default(),
+        None => HashMap::new(),
+    };
+
+    Ok(Entity {
+        id: Some(row.get(0)?),
+        entity_type: row.get(1)?,
+        name: row.get(2)?,
+        properties,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+/// Load multiple entities by ID, batching into `IN (...)` queries to avoid the
+/// N+1 pattern of one query per id. Ids are queried in chunks to stay under
+/// SQLite's bound-parameter limit; missing ids are simply absent from the
+/// result, and order is not guaranteed.
+pub(crate) fn get_entities_by_ids(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Entity>> {
+    // SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 on older builds; stay
+    // comfortably below it.
+    const CHUNK: usize = 900;
+
+    let mut result = Vec::with_capacity(ids.len());
+    for chunk in ids.chunks(CHUNK) {
+        let placeholders = std::iter::repeat("?")
+            .take(chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT id, entity_type, name, properties, created_at, updated_at \
+             FROM kg_entities WHERE id IN ({placeholders})"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(chunk.iter()), row_to_entity)?;
+        for row in rows {
+            result.push(row?);
+        }
+    }
+    Ok(result)
 }
 
 /// List entities with optional filtering.
@@ -131,23 +162,7 @@ pub fn list_entities(
     // Convert boxed params to references for query_map
     let params_refs: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
 
-    let entities = stmt.query_map(params_refs.as_slice(), |row| {
-        // Handle NULL properties column
-        let properties_json: Option<String> = row.get(3)?;
-        let properties: HashMap<String, serde_json::Value> = match properties_json {
-            Some(json) => serde_json::from_str(&json).unwrap_or_default(),
-            None => HashMap::new(),
-        };
-
-        Ok(Entity {
-            id: Some(row.get(0)?),
-            entity_type: row.get(1)?,
-            name: row.get(2)?,
-            properties,
-            created_at: row.get(4)?,
-            updated_at: row.get(5)?,
-        })
-    })?;
+    let entities = stmt.query_map(params_refs.as_slice(), row_to_entity)?;
 
     let mut result = Vec::new();
     for entity in entities {
@@ -243,6 +258,32 @@ mod tests {
 
         let all = list_entities(&conn, None, Some(2)).unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_get_entities_by_ids_batches_and_skips_missing() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+
+        let id1 = insert_entity(&conn, &Entity::new("paper", "Paper 1")).unwrap();
+        let id2 = insert_entity(&conn, &Entity::new("paper", "Paper 2")).unwrap();
+
+        // Request both real ids plus a non-existent one; missing ids are skipped.
+        let loaded = get_entities_by_ids(&conn, &[id1, 99999, id2]).unwrap();
+        assert_eq!(loaded.len(), 2);
+        let names: std::collections::HashSet<&str> =
+            loaded.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains("Paper 1"));
+        assert!(names.contains("Paper 2"));
+    }
+
+    #[test]
+    fn test_get_entities_by_ids_empty() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+
+        let loaded = get_entities_by_ids(&conn, &[]).unwrap();
+        assert!(loaded.is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod migrate;
 pub mod rag;
 pub mod schema;
 pub mod vector;
+pub mod version;
 
 #[cfg(feature = "async")]
 pub mod async_kg;
@@ -90,6 +91,7 @@ pub use schema::{create_schema, schema_exists};
 pub use vector::{cosine_similarity, SearchResult, VectorStore};
 pub use vector::{ConfidenceEngine, ConfidenceParams};
 pub use vector::{TurboQuantConfig, TurboQuantIndex, TurboQuantStats};
+pub use version::{MergeStrategy, Version, VersionDiff};
 
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -465,6 +467,108 @@ impl KnowledgeGraph {
         }
 
         Ok(entities_with_results)
+    }
+
+    // ========== QuaQue Versioning ==========
+
+    /// Create a new named version (snapshot point).
+    pub fn version_create(
+        &self,
+        name: &str,
+        branch: &str,
+        parent_id: Option<i64>,
+        description: Option<&str>,
+    ) -> Result<i64> {
+        version::store::create_version(&self.conn, name, branch, parent_id, description)
+    }
+
+    /// Delete a version by ID.
+    pub fn version_delete(&self, version_id: i64) -> Result<()> {
+        version::store::delete_version(&self.conn, version_id)
+    }
+
+    /// List versions, optionally filtered by branch.
+    pub fn version_list(&self, branch: Option<&str>) -> Result<Vec<Version>> {
+        version::store::list_versions(&self.conn, branch)
+    }
+
+    /// Add an entity to a version.
+    pub fn version_add_entity(&self, version_id: i64, entity_id: i64) -> Result<()> {
+        version::snapshot::version_add_entity(&self.conn, version_id, entity_id)
+    }
+
+    /// Remove an entity from a version.
+    pub fn version_remove_entity(&self, version_id: i64, entity_id: i64) -> Result<()> {
+        version::snapshot::version_remove_entity(&self.conn, version_id, entity_id)
+    }
+
+    /// Add a relation to a version.
+    pub fn version_add_relation(&self, version_id: i64, relation_id: i64) -> Result<()> {
+        version::snapshot::version_add_relation(&self.conn, version_id, relation_id)
+    }
+
+    /// Remove a relation from a version.
+    pub fn version_remove_relation(&self, version_id: i64, relation_id: i64) -> Result<()> {
+        version::snapshot::version_remove_relation(&self.conn, version_id, relation_id)
+    }
+
+    /// Snapshot all entities into a version.
+    pub fn version_snapshot_entities(&self, version_id: i64) -> Result<()> {
+        version::snapshot::version_snapshot_entities(&self.conn, version_id)
+    }
+
+    /// Snapshot all relations into a version.
+    pub fn version_snapshot_relations(&self, version_id: i64) -> Result<()> {
+        version::snapshot::version_snapshot_relations(&self.conn, version_id)
+    }
+
+    /// Get entities in a specific version.
+    pub fn version_entities(
+        &self,
+        version_id: i64,
+        entity_type: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Vec<Entity>> {
+        version::query::version_entities(&self.conn, version_id, entity_type, limit)
+    }
+
+    /// Get relations in a specific version.
+    pub fn version_relations(
+        &self,
+        version_id: i64,
+        rel_type: Option<&str>,
+    ) -> Result<Vec<Relation>> {
+        version::query::version_relations(&self.conn, version_id, rel_type, None, None, None)
+    }
+
+    /// Get neighbors of an entity in a specific version.
+    pub fn version_neighbors(
+        &self,
+        entity_id: i64,
+        version_id: i64,
+        depth: u32,
+    ) -> Result<Vec<Neighbor>> {
+        version::query::version_neighbors(&self.conn, entity_id, version_id, depth)
+    }
+
+    /// Compare two versions.
+    pub fn version_compare(&self, v1_id: i64, v2_id: i64) -> Result<VersionDiff> {
+        version::diff::version_compare(&self.conn, v1_id, v2_id)
+    }
+
+    /// Get all versions containing a given entity.
+    pub fn version_entity_history(&self, entity_id: i64) -> Result<Vec<Version>> {
+        version::diff::version_entity_history(&self.conn, entity_id)
+    }
+
+    /// Merge two or more versions into a new version.
+    pub fn version_merge(
+        &self,
+        source_ids: &[i64],
+        target_name: &str,
+        strategy: MergeStrategy,
+    ) -> Result<i64> {
+        version::merge::version_merge(&self.conn, source_ids, target_name, strategy)
     }
 
     /// Get context around an entity using graph traversal.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,13 +10,15 @@
 //! |---------|---------|
 //! | 1       | Initial schema: entities, relations, vectors, hyperedges, turboquant cache |
 //! | 2       | Add `vectors_checksum` column to `kg_turboquant_cache` |
+//! | 3       | SmartVector: temporal awareness, confidence decay, dependencies |
+//! | 4       | QuaQue versioning: `kg_versions` table, `validity` columns on entities/relations |
 
 use rusqlite::Connection;
 
 use crate::error::{Error, Result};
 
 /// Latest known schema version.  Bump this whenever a new migration is added.
-const CURRENT_SCHEMA_VERSION: i32 = 3;
+const CURRENT_SCHEMA_VERSION: i32 = 4;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
@@ -108,6 +110,7 @@ fn apply_migration(conn: &Connection, version: i32) -> Result<()> {
         1 => migration_v1(conn),
         2 => migration_v2(conn),
         3 => migration_v3(conn),
+        4 => migration_v4(conn),
         _ => Err(Error::Other(format!(
             "Unknown schema migration version: {}",
             version
@@ -256,6 +259,42 @@ fn migration_v3(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Migration v4 — QuaQue versioning: versions table and validity columns.
+///
+/// Adds a `kg_versions` table for version metadata and a `validity` bitstring
+/// column to `kg_entities` and `kg_relations`.  NULL validity means "unversioned,
+/// visible in all queries".  Non-NULL bitstring tracks which versions the row
+/// belongs to.
+///
+/// Each version owns a `bit_slot` in `[0, 63]` (the bit position it occupies in
+/// the validity bitstring), assigned at creation and freed on deletion.  The
+/// `UNIQUE` constraint guarantees no two live versions share a slot, and the
+/// 0–63 range is what makes the 64-version concurrency limit a hard, reclaimable
+/// boundary rather than an unbounded function of the auto-increment id.
+fn migration_v4(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS kg_versions (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            name        TEXT NOT NULL UNIQUE,
+            branch      TEXT NOT NULL DEFAULT 'main',
+            parent_id   INTEGER REFERENCES kg_versions(id) ON DELETE SET NULL,
+            description TEXT,
+            created_at  INTEGER DEFAULT (strftime('%s', 'now')),
+            is_merged   INTEGER NOT NULL DEFAULT 0,
+            bit_slot    INTEGER NOT NULL UNIQUE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_versions_branch ON kg_versions(branch);
+        CREATE INDEX IF NOT EXISTS idx_versions_parent ON kg_versions(parent_id);
+
+        ALTER TABLE kg_entities ADD COLUMN validity INTEGER DEFAULT NULL;
+        ALTER TABLE kg_relations ADD COLUMN validity INTEGER DEFAULT NULL;
+    "#,
+    )?;
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -318,6 +357,7 @@ mod tests {
             "kg_hyperedge_entities",
             "kg_turboquant_cache",
             "kg_schema_version",
+            "kg_versions",
             "kg_dependencies",
             "kg_confidence_log",
         ];
@@ -390,5 +430,72 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         create_schema(&conn).unwrap();
         assert_eq!(schema_version(&conn).unwrap(), Some(CURRENT_SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn test_v4_validity_columns_exist() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        // Verify validity column on kg_entities (NULL by default)
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('test', 'V')",
+            [],
+        )
+        .unwrap();
+        let validity: Option<i64> = conn
+            .query_row(
+                "SELECT validity FROM kg_entities WHERE name = 'V'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(validity, None);
+
+        // Verify validity column on kg_relations
+        let eid: i64 = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('test', 'V2')",
+            [],
+        )
+        .unwrap();
+        let eid2: i64 = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO kg_relations (source_id, target_id, rel_type) VALUES (?1, ?2, 'rel')",
+            rusqlite::params![eid, eid2],
+        )
+        .unwrap();
+        let rel_validity: Option<i64> = conn
+            .query_row(
+                "SELECT validity FROM kg_relations WHERE source_id = ?1",
+                [eid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rel_validity, None);
+    }
+
+    #[test]
+    fn test_v4_versions_table_writable() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO kg_versions (name, branch, description, bit_slot) \
+             VALUES ('v1', 'main', 'first', 0)",
+            [],
+        )
+        .unwrap();
+
+        let (name, branch, desc): (String, String, Option<String>) = conn
+            .query_row(
+                "SELECT name, branch, description FROM kg_versions WHERE name = 'v1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(name, "v1");
+        assert_eq!(branch, "main");
+        assert_eq!(desc.as_deref(), Some("first"));
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -282,7 +282,7 @@ fn migration_v4(conn: &Connection) -> Result<()> {
             description TEXT,
             created_at  INTEGER DEFAULT (strftime('%s', 'now')),
             is_merged   INTEGER NOT NULL DEFAULT 0,
-            bit_slot    INTEGER NOT NULL UNIQUE
+            bit_slot    INTEGER NOT NULL UNIQUE CHECK (bit_slot BETWEEN 0 AND 63)
         );
 
         CREATE INDEX IF NOT EXISTS idx_versions_branch ON kg_versions(branch);

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -81,11 +81,7 @@ fn partition(ids1: &[i64], ids2: &[i64]) -> (Vec<i64>, Vec<i64>, Vec<i64>) {
 }
 
 fn load_entities(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Entity>> {
-    let mut result = Vec::new();
-    for &id in ids {
-        result.push(crate::graph::entity::get_entity(conn, id)?);
-    }
-    Ok(result)
+    crate::graph::entity::get_entities_by_ids(conn, ids)
 }
 
 fn load_relations(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Relation>> {

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -89,12 +89,12 @@ fn load_entities(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Entity>
 }
 
 fn load_relations(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Relation>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, source_id, target_id, rel_type, weight, properties, created_at \
+         FROM kg_relations WHERE id = ?1",
+    )?;
     let mut result = Vec::new();
     for &id in ids {
-        let mut stmt = conn.prepare(
-            "SELECT id, source_id, target_id, rel_type, weight, properties, created_at \
-             FROM kg_relations WHERE id = ?1",
-        )?;
         let rel = stmt.query_row([id], |row| {
             let props_json: Option<String> = row.get(5)?;
             let properties = props_json

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -1,0 +1,227 @@
+//! Version comparison and entity history.
+
+use super::store;
+use super::Version;
+use super::VersionDiff;
+use crate::error::Result;
+use crate::graph::entity::Entity;
+use crate::graph::relation::Relation;
+
+/// Compare two versions and return added/removed/common entities and relations.
+pub fn version_compare(conn: &rusqlite::Connection, v1_id: i64, v2_id: i64) -> Result<VersionDiff> {
+    store::ensure_version_exists(conn, v1_id)?;
+    store::ensure_version_exists(conn, v2_id)?;
+
+    let ents1 = entity_ids_in_version(conn, v1_id)?;
+    let ents2 = entity_ids_in_version(conn, v2_id)?;
+
+    let rels1 = relation_ids_in_version(conn, v1_id)?;
+    let rels2 = relation_ids_in_version(conn, v2_id)?;
+
+    let (added_e, removed_e, common_e) = partition(&ents1, &ents2);
+    let (added_r, removed_r, common_r) = partition(&rels1, &rels2);
+
+    Ok(VersionDiff {
+        added_entities: load_entities(conn, &added_e)?,
+        removed_entities: load_entities(conn, &removed_e)?,
+        common_entities: load_entities(conn, &common_e)?,
+        added_relations: load_relations(conn, &added_r)?,
+        removed_relations: load_relations(conn, &removed_r)?,
+        common_relations: load_relations(conn, &common_r)?,
+    })
+}
+
+/// Return all versions that contain a given entity.
+pub fn version_entity_history(conn: &rusqlite::Connection, entity_id: i64) -> Result<Vec<Version>> {
+    store::ensure_entity_exists(conn, entity_id)?;
+
+    let validity: Option<i64> = conn.query_row(
+        "SELECT validity FROM kg_entities WHERE id = ?1",
+        [entity_id],
+        |r| r.get(0),
+    )?;
+
+    let Some(bits) = validity else {
+        return Ok(Vec::new());
+    };
+
+    // Resolve the set bits back to their owning versions (newest first).
+    store::versions_for_bits(conn, bits)
+}
+
+fn entity_ids_in_version(conn: &rusqlite::Connection, version_id: i64) -> Result<Vec<i64>> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    let mut stmt = conn.prepare("SELECT id FROM kg_entities WHERE (validity & ?1) != 0")?;
+    let ids: Vec<i64> = stmt
+        .query_map([bit], |r| r.get(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(ids)
+}
+
+fn relation_ids_in_version(conn: &rusqlite::Connection, version_id: i64) -> Result<Vec<i64>> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    let mut stmt = conn.prepare("SELECT id FROM kg_relations WHERE (validity & ?1) != 0")?;
+    let ids: Vec<i64> = stmt
+        .query_map([bit], |r| r.get(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(ids)
+}
+
+fn partition(ids1: &[i64], ids2: &[i64]) -> (Vec<i64>, Vec<i64>, Vec<i64>) {
+    let set1: std::collections::HashSet<i64> = ids1.iter().copied().collect();
+    let set2: std::collections::HashSet<i64> = ids2.iter().copied().collect();
+
+    let added: Vec<i64> = set2.difference(&set1).copied().collect();
+    let removed: Vec<i64> = set1.difference(&set2).copied().collect();
+    let common: Vec<i64> = set1.intersection(&set2).copied().collect();
+
+    (added, removed, common)
+}
+
+fn load_entities(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Entity>> {
+    let mut result = Vec::new();
+    for &id in ids {
+        result.push(crate::graph::entity::get_entity(conn, id)?);
+    }
+    Ok(result)
+}
+
+fn load_relations(conn: &rusqlite::Connection, ids: &[i64]) -> Result<Vec<Relation>> {
+    let mut result = Vec::new();
+    for &id in ids {
+        let mut stmt = conn.prepare(
+            "SELECT id, source_id, target_id, rel_type, weight, properties, created_at \
+             FROM kg_relations WHERE id = ?1",
+        )?;
+        let rel = stmt.query_row([id], |row| {
+            let props_json: Option<String> = row.get(5)?;
+            let properties = props_json
+                .and_then(|j| serde_json::from_str(&j).ok())
+                .unwrap_or_default();
+            Ok(Relation {
+                id: Some(row.get(0)?),
+                source_id: row.get(1)?,
+                target_id: row.get(2)?,
+                rel_type: row.get(3)?,
+                weight: crate::row_get_weight(row, 4)?,
+                properties,
+                created_at: row.get(6)?,
+            })
+        })?;
+        result.push(rel);
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        conn
+    }
+
+    fn add_entity(conn: &Connection, name: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('test', ?1)",
+            [name],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn add_relation(conn: &Connection, src: i64, tgt: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_relations (source_id, target_id, rel_type) VALUES (?1, ?2, 'rel')",
+            rusqlite::params![src, tgt],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn make_version(conn: &Connection, name: &str) -> i64 {
+        super::super::store::create_version(conn, name, "main", None, None).unwrap()
+    }
+
+    fn set_validity(conn: &Connection, table: &str, id: i64, val: i64) {
+        conn.execute(
+            &format!("UPDATE {table} SET validity = ?1 WHERE id = ?2"),
+            rusqlite::params![val, id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_added_entities() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        set_validity(&conn, "kg_entities", e1, 0b01); // v1
+        set_validity(&conn, "kg_entities", e2, 0b11); // v1 + v2
+        set_validity(&conn, "kg_entities", e3, 0b10); // v2
+
+        let diff = version_compare(&conn, v1, v2).unwrap();
+        assert_eq!(diff.added_entities.len(), 1);
+        assert_eq!(diff.added_entities[0].name, "C");
+        assert_eq!(diff.removed_entities.len(), 1);
+        assert_eq!(diff.removed_entities[0].name, "A");
+        assert_eq!(diff.common_entities.len(), 1);
+        assert_eq!(diff.common_entities[0].name, "B");
+    }
+
+    #[test]
+    fn test_relations_diff() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let r1 = add_relation(&conn, e1, e2);
+        let r2 = add_relation(&conn, e2, e3);
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        set_validity(&conn, "kg_relations", r1, 0b11); // both
+        set_validity(&conn, "kg_relations", r2, 0b10); // v2 only
+
+        let diff = version_compare(&conn, v1, v2).unwrap();
+        assert_eq!(diff.added_relations.len(), 1);
+        assert_eq!(diff.common_relations.len(), 1);
+    }
+
+    #[test]
+    fn test_entity_history_multi_version() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        // validity = bit for v1 | bit for v2
+        let validity = super::super::store::version_bit_for(&conn, v1).unwrap()
+            | super::super::store::version_bit_for(&conn, v2).unwrap();
+        set_validity(&conn, "kg_entities", e1, validity);
+
+        let history = version_entity_history(&conn, e1).unwrap();
+        assert_eq!(history.len(), 2);
+        let ids: Vec<i64> = history.iter().map(|v| v.id).collect();
+        assert!(ids.contains(&v1));
+        assert!(ids.contains(&v2));
+    }
+
+    #[test]
+    fn test_entity_history_unversioned() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+
+        let history = version_entity_history(&conn, e1).unwrap();
+        assert!(history.is_empty());
+    }
+}

--- a/src/version/merge.rs
+++ b/src/version/merge.rs
@@ -1,0 +1,272 @@
+//! Version merge operations — union and intersection strategies.
+
+use rusqlite::params;
+
+use super::store;
+use super::MergeStrategy;
+use crate::error::{Error, Result};
+
+/// Merge two or more versions into a new version.
+///
+/// The entire merge — new-version creation, `is_merged` flag, and all validity
+/// updates — runs in one transaction, so a failure leaves no half-built version.
+pub fn version_merge(
+    conn: &rusqlite::Connection,
+    source_ids: &[i64],
+    target_name: &str,
+    strategy: MergeStrategy,
+) -> Result<i64> {
+    if source_ids.len() < 2 {
+        return Err(Error::InvalidMerge(
+            "merge requires at least 2 source versions".to_string(),
+        ));
+    }
+
+    // Combine source slots into one mask, validating each version exists.
+    let mut source_mask: i64 = 0;
+    for &sid in source_ids {
+        source_mask |= store::version_bit_for(conn, sid)?;
+    }
+
+    let tx = conn.unchecked_transaction()?;
+
+    let new_id = store::create_version(
+        &tx,
+        target_name,
+        "main",
+        Some(source_ids[0]),
+        Some(&format!("merge of {:?}", source_ids)),
+    )?;
+    tx.execute(
+        "UPDATE kg_versions SET is_merged = 1 WHERE id = ?1",
+        [new_id],
+    )?;
+
+    let new_bit = store::version_bit_for(&tx, new_id)?;
+    match strategy {
+        MergeStrategy::Union => apply_merge(&tx, new_bit, source_mask, MergeStrategy::Union)?,
+        MergeStrategy::Intersection => {
+            apply_merge(&tx, new_bit, source_mask, MergeStrategy::Intersection)?
+        }
+    }
+
+    tx.commit()?;
+    Ok(new_id)
+}
+
+/// Set `new_bit` on every entity and relation that matches the strategy:
+/// - Union: validity overlaps ANY source bit → `(validity & mask) != 0`
+/// - Intersection: validity covers ALL source bits → `(validity & mask) = mask`
+fn apply_merge(
+    conn: &rusqlite::Connection,
+    new_bit: i64,
+    source_mask: i64,
+    strategy: MergeStrategy,
+) -> Result<()> {
+    let predicate = match strategy {
+        MergeStrategy::Union => "(validity & ?2) != 0",
+        MergeStrategy::Intersection => "(validity & ?2) = ?2",
+    };
+
+    for table in ["kg_entities", "kg_relations"] {
+        // `table` is a hard-coded literal, never user input.
+        conn.execute(
+            &format!(
+                "UPDATE {table} SET validity = validity | ?1 \
+                 WHERE validity IS NOT NULL AND {predicate}"
+            ),
+            params![new_bit, source_mask],
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        conn
+    }
+
+    fn add_entity(conn: &Connection, name: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('test', ?1)",
+            [name],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn add_relation(conn: &Connection, src: i64, tgt: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_relations (source_id, target_id, rel_type) VALUES (?1, ?2, 'rel')",
+            rusqlite::params![src, tgt],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn make_version(conn: &Connection, name: &str) -> i64 {
+        super::super::store::create_version(conn, name, "main", None, None).unwrap()
+    }
+
+    fn set_validity(conn: &Connection, table: &str, id: i64, val: i64) {
+        conn.execute(
+            &format!("UPDATE {table} SET validity = ?1 WHERE id = ?2"),
+            rusqlite::params![val, id],
+        )
+        .unwrap();
+    }
+
+    fn get_validity(conn: &Connection, table: &str, id: i64) -> Option<i64> {
+        conn.query_row(
+            &format!("SELECT validity FROM {table} WHERE id = ?1"),
+            [id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_union_merge() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        // v1: A, B
+        set_validity(&conn, "kg_entities", e1, 0b01);
+        set_validity(&conn, "kg_entities", e2, 0b01);
+        // v2: B, C
+        set_validity(&conn, "kg_entities", e3, 0b10);
+        conn.execute(
+            "UPDATE kg_entities SET validity = validity | 2 WHERE id = ?1",
+            [e2],
+        )
+        .unwrap(); // B in both: 0b11
+
+        let merged = version_merge(&conn, &[v1, v2], "merged-union", MergeStrategy::Union).unwrap();
+        let mb = store::version_bit_for(&conn, merged).unwrap();
+
+        // All three should have the merged version's bit
+        assert!(get_validity(&conn, "kg_entities", e1).unwrap() & mb != 0);
+        assert!(get_validity(&conn, "kg_entities", e2).unwrap() & mb != 0);
+        assert!(get_validity(&conn, "kg_entities", e3).unwrap() & mb != 0);
+    }
+
+    #[test]
+    fn test_intersection_merge() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        // v1: A, B
+        set_validity(&conn, "kg_entities", e1, 0b01);
+        set_validity(&conn, "kg_entities", e2, 0b11); // B in both
+                                                      // v2: B, C
+        set_validity(&conn, "kg_entities", e3, 0b10);
+
+        let merged = version_merge(
+            &conn,
+            &[v1, v2],
+            "merged-intersect",
+            MergeStrategy::Intersection,
+        )
+        .unwrap();
+        let mb = store::version_bit_for(&conn, merged).unwrap();
+
+        // Only B should be in the intersection
+        assert!(get_validity(&conn, "kg_entities", e1).unwrap() & mb == 0);
+        assert!(get_validity(&conn, "kg_entities", e2).unwrap() & mb != 0);
+        assert!(get_validity(&conn, "kg_entities", e3).unwrap() & mb == 0);
+    }
+
+    #[test]
+    fn test_merge_applies_to_relations() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let r1 = add_relation(&conn, e1, e2);
+        let r2 = add_relation(&conn, e2, e3);
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        set_validity(&conn, "kg_relations", r1, 0b11); // both versions
+        set_validity(&conn, "kg_relations", r2, 0b10); // v2 only
+
+        // Union: both relations carry the merged bit; intersection: only r1.
+        let mu = version_merge(&conn, &[v1, v2], "u", MergeStrategy::Union).unwrap();
+        let mub = store::version_bit_for(&conn, mu).unwrap();
+        assert!(get_validity(&conn, "kg_relations", r1).unwrap() & mub != 0);
+        assert!(get_validity(&conn, "kg_relations", r2).unwrap() & mub != 0);
+
+        let mi = version_merge(&conn, &[v1, v2], "i", MergeStrategy::Intersection).unwrap();
+        let mib = store::version_bit_for(&conn, mi).unwrap();
+        assert!(get_validity(&conn, "kg_relations", r1).unwrap() & mib != 0);
+        assert!(get_validity(&conn, "kg_relations", r2).unwrap() & mib == 0);
+    }
+
+    #[test]
+    fn test_merge_creates_version_row() {
+        let conn = setup();
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+
+        let merged = version_merge(&conn, &[v1, v2], "merged", MergeStrategy::Union).unwrap();
+
+        let v = super::super::store::get_version(&conn, merged).unwrap();
+        assert_eq!(v.name, "merged");
+        assert_eq!(v.parent_id, Some(v1));
+        assert!(v.is_merged);
+    }
+
+    #[test]
+    fn test_delete_parent_after_merge_reclaims_slot() {
+        // Production connections enable foreign keys; ON DELETE SET NULL only
+        // fires under enforcement, so opt in explicitly here.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+
+        let v1 = make_version(&conn, "v1");
+        let v2 = make_version(&conn, "v2");
+        let merged = version_merge(&conn, &[v1, v2], "m", MergeStrategy::Union).unwrap();
+        let freed_bit = store::version_bit_for(&conn, v1).unwrap();
+
+        // v1 is the merged version's parent; deleting it must succeed (not RESTRICT).
+        store::delete_version(&conn, v1).unwrap();
+
+        // The merged child's parent_id was nulled, not left dangling.
+        assert_eq!(store::get_version(&conn, merged).unwrap().parent_id, None);
+
+        // v1's slot is reclaimed: the next version reuses that exact bit.
+        let v3 = make_version(&conn, "v3");
+        assert_eq!(store::version_bit_for(&conn, v3).unwrap(), freed_bit);
+    }
+
+    #[test]
+    fn test_merge_single_source_rejected() {
+        let conn = setup();
+        let v1 = make_version(&conn, "v1");
+        let err = version_merge(&conn, &[v1], "bad", MergeStrategy::Union).unwrap_err();
+        assert!(matches!(err, Error::InvalidMerge(_)));
+    }
+
+    #[test]
+    fn test_merge_nonexistent_version_rejected() {
+        let conn = setup();
+        let v1 = make_version(&conn, "v1");
+        let err = version_merge(&conn, &[v1, 999], "bad", MergeStrategy::Union).unwrap_err();
+        assert!(matches!(err, Error::VersionNotFound(999)));
+    }
+}

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,0 +1,62 @@
+//! QuaQue-inspired versioning for the knowledge graph.
+//!
+//! Based on arXiv:2603.18654 — condensed relational model using bitstring validity.
+//! Each entity/relation row carries a `validity` bitstring where bit N = 1 means
+//! the row exists in version N+1.  Version filtering uses bitwise operations.
+
+pub mod diff;
+pub mod merge;
+pub mod query;
+pub mod snapshot;
+pub mod store;
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata for a named version/snapshot of the knowledge graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Version {
+    pub id: i64,
+    pub name: String,
+    pub branch: String,
+    pub parent_id: Option<i64>,
+    pub description: Option<String>,
+    pub created_at: Option<i64>,
+    pub is_merged: bool,
+}
+
+/// Result of comparing two versions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionDiff {
+    pub added_entities: Vec<crate::graph::Entity>,
+    pub removed_entities: Vec<crate::graph::Entity>,
+    pub common_entities: Vec<crate::graph::Entity>,
+    pub added_relations: Vec<crate::graph::Relation>,
+    pub removed_relations: Vec<crate::graph::Relation>,
+    pub common_relations: Vec<crate::graph::Relation>,
+}
+
+/// Strategy for merging versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeStrategy {
+    /// Entity/relation exists in merged version if it exists in ANY source version.
+    Union,
+    /// Entity/relation exists in merged version only if it exists in ALL source versions.
+    Intersection,
+}
+
+/// Maximum number of concurrent versions, bounded by the 64 usable bits of a
+/// signed 64-bit `validity` column.
+pub(crate) const MAX_VERSIONS: i64 = 64;
+
+/// Compute the validity bitmask for a `bit_slot` in `[0, 63]`.
+///
+/// Slots — not version ids — drive the bit position so the limit is exactly 64
+/// *concurrent* versions (slots are reclaimed on delete) instead of 64 version
+/// *creations* over the database lifetime.  Callers obtain a version's slot via
+/// [`store::version_bit_for`], which validates existence; this helper only does
+/// the shift and assumes a validated slot.
+#[inline]
+pub(crate) fn bit_from_slot(slot: i64) -> i64 {
+    debug_assert!((0..MAX_VERSIONS).contains(&slot), "bit_slot out of range");
+    1 << slot
+}

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -51,15 +51,20 @@ pub enum MergeStrategy {
 /// signed 64-bit `validity` column.
 pub(crate) const MAX_VERSIONS: i64 = 64;
 
-/// Compute the validity bitmask for a `bit_slot` in `[0, 63]`.
+/// Compute the validity bitmask for a `bit_slot`, or `None` if `slot` is outside
+/// `[0, 63]`.
 ///
 /// Slots — not version ids — drive the bit position so the limit is exactly 64
 /// *concurrent* versions (slots are reclaimed on delete) instead of 64 version
-/// *creations* over the database lifetime.  Callers obtain a version's slot via
-/// [`store::version_bit_for`], which validates existence; this helper only does
-/// the shift and assumes a validated slot.
+/// *creations* over the database lifetime.  Returning `None` for an out-of-range
+/// slot keeps the helper panic-free even in release builds: a corrupted/manual
+/// DB row is surfaced as a regular error by the caller (see
+/// [`store::version_bit_for`]) instead of crashing on `1 << slot`.
 #[inline]
-pub(crate) fn bit_from_slot(slot: i64) -> i64 {
-    debug_assert!((0..MAX_VERSIONS).contains(&slot), "bit_slot out of range");
-    1 << slot
+pub(crate) fn bit_from_slot(slot: i64) -> Option<i64> {
+    if (0..MAX_VERSIONS).contains(&slot) {
+        Some(1 << slot)
+    } else {
+        None
+    }
 }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,8 +1,11 @@
 //! QuaQue-inspired versioning for the knowledge graph.
 //!
 //! Based on arXiv:2603.18654 — condensed relational model using bitstring validity.
-//! Each entity/relation row carries a `validity` bitstring where bit N = 1 means
-//! the row exists in version N+1.  Version filtering uses bitwise operations.
+//! Each entity/relation row carries a `validity` bitstring; bit position is determined
+//! by a version's `bit_slot` (0–63), NOT by its `id`.  Slots are reclaimable: when a
+//! version is deleted its slot is freed and the next `create_version` call reuses the
+//! lowest available slot.  A row belongs to version V when
+//! `(validity & (1 << V.bit_slot)) != 0`.  Version filtering uses bitwise operations.
 
 pub mod diff;
 pub mod merge;

--- a/src/version/query.rs
+++ b/src/version/query.rs
@@ -1,0 +1,428 @@
+//! Version-filtered queries for entities, relations, and neighbor traversal.
+
+use std::collections::{HashSet, VecDeque};
+
+use rusqlite::params;
+
+use super::store;
+use crate::error::{Error, Result};
+use crate::graph::entity::Entity;
+use crate::graph::relation::Relation;
+
+/// Get all entities in a specific version.
+pub fn version_entities(
+    conn: &rusqlite::Connection,
+    version_id: i64,
+    entity_type: Option<&str>,
+    limit: Option<i64>,
+) -> Result<Vec<Entity>> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    let mut query = String::from(
+        "SELECT id, entity_type, name, properties, created_at, updated_at \
+         FROM kg_entities WHERE (validity & ?1) != 0",
+    );
+
+    let mut param_idx = 2;
+    if entity_type.is_some() {
+        query.push_str(&format!(" AND entity_type = ?{param_idx}"));
+        param_idx += 1;
+    }
+
+    if limit.is_some() {
+        query.push_str(&format!(" LIMIT ?{param_idx}"));
+    }
+
+    let mut stmt = conn.prepare(&query)?;
+
+    let mut param_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(bit)];
+    if let Some(et) = entity_type {
+        param_vec.push(Box::new(et.to_string()));
+    }
+    if let Some(lim) = limit {
+        param_vec.push(Box::new(lim));
+    }
+
+    let params_refs: Vec<&dyn rusqlite::ToSql> = param_vec.iter().map(|p| p.as_ref()).collect();
+
+    let entities = stmt.query_map(params_refs.as_slice(), row_to_entity)?;
+
+    let mut result = Vec::new();
+    for e in entities {
+        result.push(e?);
+    }
+    Ok(result)
+}
+
+/// Get all relations in a specific version.
+pub fn version_relations(
+    conn: &rusqlite::Connection,
+    version_id: i64,
+    rel_type: Option<&str>,
+    source_id: Option<i64>,
+    target_id: Option<i64>,
+    limit: Option<i64>,
+) -> Result<Vec<Relation>> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    let mut query = String::from(
+        "SELECT id, source_id, target_id, rel_type, weight, properties, created_at \
+         FROM kg_relations WHERE (validity & ?1) != 0",
+    );
+
+    let mut param_idx = 2;
+    if rel_type.is_some() {
+        query.push_str(&format!(" AND rel_type = ?{param_idx}"));
+        param_idx += 1;
+    }
+    if source_id.is_some() {
+        query.push_str(&format!(" AND source_id = ?{param_idx}"));
+        param_idx += 1;
+    }
+    if target_id.is_some() {
+        query.push_str(&format!(" AND target_id = ?{param_idx}"));
+        param_idx += 1;
+    }
+    if limit.is_some() {
+        query.push_str(&format!(" LIMIT ?{param_idx}"));
+    }
+
+    let mut stmt = conn.prepare(&query)?;
+
+    let mut param_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(bit)];
+    if let Some(rt) = rel_type {
+        param_vec.push(Box::new(rt.to_string()));
+    }
+    if let Some(sid) = source_id {
+        param_vec.push(Box::new(sid));
+    }
+    if let Some(tid) = target_id {
+        param_vec.push(Box::new(tid));
+    }
+    if let Some(lim) = limit {
+        param_vec.push(Box::new(lim));
+    }
+
+    let params_refs: Vec<&dyn rusqlite::ToSql> = param_vec.iter().map(|p| p.as_ref()).collect();
+
+    let relations = stmt.query_map(params_refs.as_slice(), row_to_relation)?;
+
+    let mut result = Vec::new();
+    for r in relations {
+        result.push(r?);
+    }
+    Ok(result)
+}
+
+/// Version-aware neighbor traversal. Both the entity and the connecting relation
+/// must exist in the specified version.
+pub fn version_neighbors(
+    conn: &rusqlite::Connection,
+    entity_id: i64,
+    version_id: i64,
+    depth: u32,
+) -> Result<Vec<crate::graph::relation::Neighbor>> {
+    if depth == 0 {
+        return Ok(Vec::new());
+    }
+    if depth > 5 {
+        return Err(Error::InvalidDepth(depth));
+    }
+
+    let bit = store::version_bit_for(conn, version_id)?;
+    store::ensure_entity_exists(conn, entity_id)?;
+
+    // The traversal only crosses edges/nodes that live in this version; a start
+    // entity outside the version has no in-version neighborhood.
+    if !entity_in_version(conn, entity_id, bit)? {
+        return Ok(Vec::new());
+    }
+
+    let mut result = Vec::new();
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+
+    visited.insert(entity_id);
+
+    let direct = get_direct_version_relations(conn, entity_id, bit)?;
+    for (relation, neighbor_entity) in direct {
+        let nid = neighbor_entity.id.ok_or(Error::EntityNotFound(0))?;
+        if !visited.contains(&nid) {
+            visited.insert(nid);
+            queue.push_back((nid, 1));
+            result.push(crate::graph::relation::Neighbor {
+                entity: neighbor_entity,
+                relation,
+            });
+        }
+    }
+
+    while let Some((current_id, current_depth)) = queue.pop_front() {
+        if current_depth >= depth {
+            continue;
+        }
+
+        let relations = get_direct_version_relations(conn, current_id, bit)?;
+        for (relation, neighbor_entity) in relations {
+            let nid = neighbor_entity.id.ok_or(Error::EntityNotFound(0))?;
+            if !visited.contains(&nid) {
+                visited.insert(nid);
+                queue.push_back((nid, current_depth + 1));
+                result.push(crate::graph::relation::Neighbor {
+                    entity: neighbor_entity,
+                    relation,
+                });
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Whether an entity's validity bitstring includes the given version bit.
+fn entity_in_version(conn: &rusqlite::Connection, entity_id: i64, bit: i64) -> Result<bool> {
+    let present: bool = conn.query_row(
+        "SELECT COALESCE((validity & ?1) != 0, 0) FROM kg_entities WHERE id = ?2",
+        params![bit, entity_id],
+        |r| r.get(0),
+    )?;
+    Ok(present)
+}
+
+/// Get direct version-filtered relations for an entity (both directions).
+fn get_direct_version_relations(
+    conn: &rusqlite::Connection,
+    entity_id: i64,
+    bit: i64,
+) -> Result<Vec<(Relation, Entity)>> {
+    let mut result = Vec::new();
+
+    // Outgoing: entity_id is source
+    let mut stmt = conn.prepare(
+        "SELECT r.id, r.source_id, r.target_id, r.rel_type, r.weight, r.properties, r.created_at,
+                e.id, e.entity_type, e.name, e.properties, e.created_at, e.updated_at
+         FROM kg_relations r
+         JOIN kg_entities e ON r.target_id = e.id
+         WHERE r.source_id = ?1 AND (r.validity & ?2) != 0 AND (e.validity & ?2) != 0",
+    )?;
+    let rows = stmt.query_map(params![entity_id, bit], |row| {
+        Ok((row_to_relation(row)?, row_to_entity_offset(row, 7)?))
+    })?;
+    for row in rows {
+        result.push(row?);
+    }
+
+    // Incoming: entity_id is target
+    let mut stmt = conn.prepare(
+        "SELECT r.id, r.source_id, r.target_id, r.rel_type, r.weight, r.properties, r.created_at,
+                e.id, e.entity_type, e.name, e.properties, e.created_at, e.updated_at
+         FROM kg_relations r
+         JOIN kg_entities e ON r.source_id = e.id
+         WHERE r.target_id = ?1 AND (r.validity & ?2) != 0 AND (e.validity & ?2) != 0",
+    )?;
+    let rows = stmt.query_map(params![entity_id, bit], |row| {
+        Ok((row_to_relation(row)?, row_to_entity_offset(row, 7)?))
+    })?;
+    for row in rows {
+        result.push(row?);
+    }
+
+    Ok(result)
+}
+
+fn row_to_entity(row: &rusqlite::Row) -> rusqlite::Result<Entity> {
+    let props_json: Option<String> = row.get(3)?;
+    let properties = props_json
+        .and_then(|j| serde_json::from_str(&j).ok())
+        .unwrap_or_default();
+    Ok(Entity {
+        id: Some(row.get(0)?),
+        entity_type: row.get(1)?,
+        name: row.get(2)?,
+        properties,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+fn row_to_entity_offset(row: &rusqlite::Row, offset: usize) -> rusqlite::Result<Entity> {
+    let props_json: Option<String> = row.get(offset + 3)?;
+    let properties = props_json
+        .and_then(|j| serde_json::from_str(&j).ok())
+        .unwrap_or_default();
+    Ok(Entity {
+        id: Some(row.get(offset)?),
+        entity_type: row.get(offset + 1)?,
+        name: row.get(offset + 2)?,
+        properties,
+        created_at: row.get(offset + 4)?,
+        updated_at: row.get(offset + 5)?,
+    })
+}
+
+fn row_to_relation(row: &rusqlite::Row) -> rusqlite::Result<Relation> {
+    let props_json: Option<String> = row.get(5)?;
+    let properties = props_json
+        .and_then(|j| serde_json::from_str(&j).ok())
+        .unwrap_or_default();
+    Ok(Relation {
+        id: Some(row.get(0)?),
+        source_id: row.get(1)?,
+        target_id: row.get(2)?,
+        rel_type: row.get(3)?,
+        weight: crate::row_get_weight(row, 4)?,
+        properties,
+        created_at: row.get(6)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        conn
+    }
+
+    fn add_entity(conn: &Connection, name: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('test', ?1)",
+            [name],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn add_relation(conn: &Connection, src: i64, tgt: i64, rt: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_relations (source_id, target_id, rel_type) VALUES (?1, ?2, ?3)",
+            rusqlite::params![src, tgt, rt],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn make_version(conn: &Connection, name: &str) -> i64 {
+        super::super::store::create_version(conn, name, "main", None, None).unwrap()
+    }
+
+    fn set_validity(conn: &Connection, table: &str, id: i64, val: i64) {
+        conn.execute(
+            &format!("UPDATE {table} SET validity = ?1 WHERE id = ?2"),
+            rusqlite::params![val, id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_entities_in_version() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let v1 = make_version(&conn, "v1");
+
+        set_validity(&conn, "kg_entities", e1, 0b01); // v1 only
+        set_validity(&conn, "kg_entities", e2, 0b01); // v1 only
+        set_validity(&conn, "kg_entities", e3, 0b10); // v2 only (doesn't exist yet)
+
+        let ents = version_entities(&conn, v1, None, None).unwrap();
+        assert_eq!(ents.len(), 2);
+        let names: Vec<&str> = ents.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"A"));
+        assert!(names.contains(&"B"));
+    }
+
+    #[test]
+    fn test_entities_with_type_filter() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('paper', 'P1')",
+            [],
+        )
+        .unwrap();
+        let e2 = add_entity(&conn, "S1");
+        let v1 = make_version(&conn, "v1");
+
+        set_validity(&conn, "kg_entities", e2, 0b01);
+        conn.execute("UPDATE kg_entities SET validity = 1 WHERE name = 'P1'", [])
+            .unwrap();
+
+        let papers = version_entities(&conn, v1, Some("paper"), None).unwrap();
+        assert_eq!(papers.len(), 1);
+        assert_eq!(papers[0].name, "P1");
+    }
+
+    #[test]
+    fn test_relations_in_version() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let r1 = add_relation(&conn, e1, e2, "cites");
+        let v1 = make_version(&conn, "v1");
+
+        set_validity(&conn, "kg_relations", r1, 0b01);
+
+        let rels = version_relations(&conn, v1, None, None, None, None).unwrap();
+        assert_eq!(rels.len(), 1);
+    }
+
+    #[test]
+    fn test_relations_with_type_filter() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let r1 = add_relation(&conn, e1, e2, "cites");
+        let r2 = add_relation(&conn, e2, e1, "related");
+        let v1 = make_version(&conn, "v1");
+
+        set_validity(&conn, "kg_relations", r1, 0b01);
+        set_validity(&conn, "kg_relations", r2, 0b01);
+
+        let cites = version_relations(&conn, v1, Some("cites"), None, None, None).unwrap();
+        assert_eq!(cites.len(), 1);
+        assert_eq!(cites[0].rel_type, "cites");
+    }
+
+    #[test]
+    fn test_version_neighbors() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let r1 = add_relation(&conn, e1, e2, "knows");
+        let r2 = add_relation(&conn, e1, e3, "knows");
+        let v1 = make_version(&conn, "v1");
+
+        set_validity(&conn, "kg_entities", e1, 0b01);
+        set_validity(&conn, "kg_entities", e2, 0b01);
+        set_validity(&conn, "kg_entities", e3, 0b01);
+        set_validity(&conn, "kg_relations", r1, 0b01);
+        set_validity(&conn, "kg_relations", r2, 0b01);
+
+        let neighbors = version_neighbors(&conn, e1, v1, 1).unwrap();
+        assert_eq!(neighbors.len(), 2);
+    }
+
+    #[test]
+    fn test_version_neighbors_excludes_non_version_entity() {
+        let conn = setup();
+        let e1 = add_entity(&conn, "A");
+        let e2 = add_entity(&conn, "B");
+        let e3 = add_entity(&conn, "C");
+        let r1 = add_relation(&conn, e1, e2, "knows");
+        let r2 = add_relation(&conn, e1, e3, "knows");
+        let v1 = make_version(&conn, "v1");
+
+        set_validity(&conn, "kg_entities", e1, 0b01);
+        set_validity(&conn, "kg_entities", e2, 0b01);
+        // e3 is NOT in v1
+        set_validity(&conn, "kg_relations", r1, 0b01);
+        set_validity(&conn, "kg_relations", r2, 0b01);
+
+        let neighbors = version_neighbors(&conn, e1, v1, 1).unwrap();
+        assert_eq!(neighbors.len(), 1);
+        assert_eq!(neighbors[0].entity.name, "B");
+    }
+}

--- a/src/version/snapshot.rs
+++ b/src/version/snapshot.rs
@@ -1,0 +1,235 @@
+//! Version snapshot operations — add/remove entities and relations to/from versions.
+
+use rusqlite::params;
+
+use super::store;
+use crate::error::Result;
+
+/// Add an entity to a version (set the bit in its validity bitstring).
+pub fn version_add_entity(
+    conn: &rusqlite::Connection,
+    version_id: i64,
+    entity_id: i64,
+) -> Result<()> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    store::ensure_entity_exists(conn, entity_id)?;
+
+    conn.execute(
+        "UPDATE kg_entities SET validity = COALESCE(validity, 0) | ?1 WHERE id = ?2",
+        params![bit, entity_id],
+    )?;
+    Ok(())
+}
+
+/// Remove an entity from a version (clear the bit). If result is 0, set to NULL.
+pub fn version_remove_entity(
+    conn: &rusqlite::Connection,
+    version_id: i64,
+    entity_id: i64,
+) -> Result<()> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    store::ensure_entity_exists(conn, entity_id)?;
+
+    // Clear the bit, then check if result is 0 → set to NULL
+    conn.execute(
+        "UPDATE kg_entities SET validity = CASE \
+         WHEN (COALESCE(validity, 0) & ~?1) = 0 THEN NULL \
+         ELSE validity & ~?1 \
+         END \
+         WHERE id = ?2",
+        params![bit, entity_id],
+    )?;
+    Ok(())
+}
+
+/// Add a relation to a version.
+pub fn version_add_relation(
+    conn: &rusqlite::Connection,
+    version_id: i64,
+    relation_id: i64,
+) -> Result<()> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    store::ensure_relation_exists(conn, relation_id)?;
+
+    conn.execute(
+        "UPDATE kg_relations SET validity = COALESCE(validity, 0) | ?1 WHERE id = ?2",
+        params![bit, relation_id],
+    )?;
+    Ok(())
+}
+
+/// Remove a relation from a version. If result is 0, set to NULL.
+pub fn version_remove_relation(
+    conn: &rusqlite::Connection,
+    version_id: i64,
+    relation_id: i64,
+) -> Result<()> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    store::ensure_relation_exists(conn, relation_id)?;
+
+    conn.execute(
+        "UPDATE kg_relations SET validity = CASE \
+         WHEN (COALESCE(validity, 0) & ~?1) = 0 THEN NULL \
+         ELSE validity & ~?1 \
+         END \
+         WHERE id = ?2",
+        params![bit, relation_id],
+    )?;
+    Ok(())
+}
+
+/// Bulk add all entities to a version in a single operation.
+pub fn version_snapshot_entities(conn: &rusqlite::Connection, version_id: i64) -> Result<()> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    conn.execute(
+        "UPDATE kg_entities SET validity = COALESCE(validity, 0) | ?1",
+        [bit],
+    )?;
+    Ok(())
+}
+
+/// Bulk add all relations to a version in a single operation.
+pub fn version_snapshot_relations(conn: &rusqlite::Connection, version_id: i64) -> Result<()> {
+    let bit = store::version_bit_for(conn, version_id)?;
+    conn.execute(
+        "UPDATE kg_relations SET validity = COALESCE(validity, 0) | ?1",
+        [bit],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        conn
+    }
+
+    fn insert_entity(conn: &Connection, name: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('test', ?1)",
+            [name],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_relation(conn: &Connection, src: i64, tgt: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_relations (source_id, target_id, rel_type) VALUES (?1, ?2, 'rel')",
+            rusqlite::params![src, tgt],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn get_validity(conn: &Connection, table: &str, id: i64) -> Option<i64> {
+        conn.query_row(
+            &format!("SELECT validity FROM {table} WHERE id = ?1"),
+            [id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_add_unversioned_entity_to_version() {
+        let conn = setup();
+        let eid = insert_entity(&conn, "A");
+        let vid = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+
+        version_add_entity(&conn, vid, eid).unwrap();
+
+        let v = get_validity(&conn, "kg_entities", eid);
+        assert_eq!(v, Some(1)); // 0b1 — version 1 (bit 0)
+    }
+
+    #[test]
+    fn test_add_entity_to_additional_version() {
+        let conn = setup();
+        let eid = insert_entity(&conn, "A");
+        let v1 = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+        let v2 = super::super::store::create_version(&conn, "v2", "main", None, None).unwrap();
+
+        version_add_entity(&conn, v1, eid).unwrap();
+        version_add_entity(&conn, v2, eid).unwrap();
+
+        let v = get_validity(&conn, "kg_entities", eid);
+        assert_eq!(v, Some(0b11)); // versions 1 and 2
+    }
+
+    #[test]
+    fn test_remove_entity_from_one_of_multiple_versions() {
+        let conn = setup();
+        let eid = insert_entity(&conn, "A");
+        let v1 = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+        let v2 = super::super::store::create_version(&conn, "v2", "main", None, None).unwrap();
+
+        version_add_entity(&conn, v1, eid).unwrap();
+        version_add_entity(&conn, v2, eid).unwrap();
+        version_remove_entity(&conn, v1, eid).unwrap();
+
+        let v = get_validity(&conn, "kg_entities", eid);
+        assert_eq!(v, Some(0b10)); // only version 2
+    }
+
+    #[test]
+    fn test_remove_entity_from_only_version_returns_null() {
+        let conn = setup();
+        let eid = insert_entity(&conn, "A");
+        let v1 = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+
+        version_add_entity(&conn, v1, eid).unwrap();
+        version_remove_entity(&conn, v1, eid).unwrap();
+
+        let v = get_validity(&conn, "kg_entities", eid);
+        assert_eq!(v, None); // back to unversioned
+    }
+
+    #[test]
+    fn test_bulk_snapshot_entities() {
+        let conn = setup();
+        let e1 = insert_entity(&conn, "A");
+        let e2 = insert_entity(&conn, "B");
+        let vid = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+
+        version_snapshot_entities(&conn, vid).unwrap();
+
+        assert_eq!(get_validity(&conn, "kg_entities", e1), Some(1));
+        assert_eq!(get_validity(&conn, "kg_entities", e2), Some(1));
+    }
+
+    #[test]
+    fn test_add_relation_to_version() {
+        let conn = setup();
+        let e1 = insert_entity(&conn, "A");
+        let e2 = insert_entity(&conn, "B");
+        let rid = insert_relation(&conn, e1, e2);
+        let vid = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+
+        version_add_relation(&conn, vid, rid).unwrap();
+
+        let v = get_validity(&conn, "kg_relations", rid);
+        assert_eq!(v, Some(1));
+    }
+
+    #[test]
+    fn test_nonexistent_entity_error() {
+        let conn = setup();
+        let vid = super::super::store::create_version(&conn, "v1", "main", None, None).unwrap();
+        let err = version_add_entity(&conn, vid, 999).unwrap_err();
+        assert!(matches!(err, crate::error::Error::EntityNotFound(999)));
+    }
+
+    #[test]
+    fn test_nonexistent_version_error() {
+        let conn = setup();
+        let eid = insert_entity(&conn, "A");
+        let err = version_add_entity(&conn, 999, eid).unwrap_err();
+        assert!(matches!(err, crate::error::Error::VersionNotFound(999)));
+    }
+}

--- a/src/version/store.rs
+++ b/src/version/store.rs
@@ -81,7 +81,9 @@ fn clear_bit(conn: &rusqlite::Connection, table: &str, bit: i64) -> Result<()> {
 }
 
 /// Resolve a version id to its validity bitmask (`1 << bit_slot`).
-/// Returns [`Error::VersionNotFound`] if the version does not exist.
+///
+/// Returns [`Error::VersionNotFound`] if the version does not exist, or
+/// [`Error::CorruptBitSlot`] if the stored `bit_slot` is outside `[0, 63]`.
 pub fn version_bit_for(conn: &rusqlite::Connection, version_id: i64) -> Result<i64> {
     let slot: i64 = conn
         .query_row(
@@ -91,12 +93,9 @@ pub fn version_bit_for(conn: &rusqlite::Connection, version_id: i64) -> Result<i
         )
         .optional()?
         .ok_or(Error::VersionNotFound(version_id))?;
-    // Guard against a corrupted/manual DB row: `bit_from_slot` shifts by `slot`,
-    // which panics for out-of-range values. Return an error instead.
-    if !(0..MAX_VERSIONS).contains(&slot) {
-        return Err(Error::CorruptBitSlot { version_id, slot });
-    }
-    Ok(bit_from_slot(slot))
+    // A corrupted/manual DB row could carry an out-of-range slot; surface it as
+    // an error instead of panicking on the shift inside `bit_from_slot`.
+    bit_from_slot(slot).ok_or(Error::CorruptBitSlot { version_id, slot })
 }
 
 /// Return every version whose `bit_slot` is set in `bits`, newest first.
@@ -356,11 +355,14 @@ mod tests {
 
         // Simulate a corrupted/manual row by bypassing the CHECK constraint so the
         // out-of-range slot reaches the read path instead of being rejected at write.
-        conn.execute_batch("PRAGMA ignore_check_constraints = ON").unwrap();
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON")
+            .unwrap();
         conn.execute("UPDATE kg_versions SET bit_slot = 64 WHERE id = ?1", [id])
             .unwrap();
 
         let err = version_bit_for(&conn, id).unwrap_err();
-        assert!(matches!(err, Error::CorruptBitSlot { version_id, slot } if version_id == id && slot == 64));
+        assert!(
+            matches!(err, Error::CorruptBitSlot { version_id, slot } if version_id == id && slot == 64)
+        );
     }
 }

--- a/src/version/store.rs
+++ b/src/version/store.rs
@@ -1,0 +1,342 @@
+//! Version CRUD operations.
+
+use rusqlite::{params, OptionalExtension};
+
+use super::{bit_from_slot, Version, MAX_VERSIONS};
+use crate::error::{Error, Result};
+
+/// Create a new version. Returns the version ID.
+///
+/// Allocates the lowest free `bit_slot` in `[0, 63]`.  Returns
+/// [`Error::VersionLimitExceeded`] when all 64 slots are occupied by live
+/// versions (deleting a version frees its slot for reuse).
+pub fn create_version(
+    conn: &rusqlite::Connection,
+    name: &str,
+    branch: &str,
+    parent_id: Option<i64>,
+    description: Option<&str>,
+) -> Result<i64> {
+    let slot = allocate_slot(conn)?;
+    conn.execute(
+        "INSERT INTO kg_versions (name, branch, parent_id, description, bit_slot) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![name, branch, parent_id, description, slot],
+    )
+    .map_err(|e| {
+        if e.to_string()
+            .contains("UNIQUE constraint failed: kg_versions.name")
+        {
+            Error::DuplicateVersionName(name.to_string())
+        } else {
+            Error::from(e)
+        }
+    })?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Find the lowest unused `bit_slot` in `[0, 63]`.
+fn allocate_slot(conn: &rusqlite::Connection) -> Result<i64> {
+    let mut stmt = conn.prepare("SELECT bit_slot FROM kg_versions")?;
+    let used: std::collections::HashSet<i64> = stmt
+        .query_map([], |r| r.get(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+    (0..MAX_VERSIONS)
+        .find(|slot| !used.contains(slot))
+        .ok_or(Error::VersionLimitExceeded)
+}
+
+/// Delete a version by ID, clearing its bit from every entity and relation so
+/// the freed slot can be safely reused by a future version.  Runs in a single
+/// transaction: either the version row and all its bits go, or nothing does.
+pub fn delete_version(conn: &rusqlite::Connection, version_id: i64) -> Result<()> {
+    let bit = version_bit_for(conn, version_id)?; // also validates existence
+
+    let tx = conn.unchecked_transaction()?;
+    clear_bit(&tx, "kg_entities", bit)?;
+    clear_bit(&tx, "kg_relations", bit)?;
+    tx.execute("DELETE FROM kg_versions WHERE id = ?1", [version_id])?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Clear `bit` from the validity column of every row in `table`, collapsing a
+/// resulting 0 back to NULL (the unversioned sentinel).
+fn clear_bit(conn: &rusqlite::Connection, table: &str, bit: i64) -> Result<()> {
+    // `table` is a hard-coded literal at every call site, never user input.
+    conn.execute(
+        &format!(
+            "UPDATE {table} SET validity = CASE \
+             WHEN (validity & ~?1) = 0 THEN NULL ELSE validity & ~?1 END \
+             WHERE validity IS NOT NULL AND (validity & ?1) != 0"
+        ),
+        [bit],
+    )?;
+    Ok(())
+}
+
+/// Resolve a version id to its validity bitmask (`1 << bit_slot`).
+/// Returns [`Error::VersionNotFound`] if the version does not exist.
+pub fn version_bit_for(conn: &rusqlite::Connection, version_id: i64) -> Result<i64> {
+    let slot: i64 = conn
+        .query_row(
+            "SELECT bit_slot FROM kg_versions WHERE id = ?1",
+            [version_id],
+            |r| r.get(0),
+        )
+        .optional()?
+        .ok_or(Error::VersionNotFound(version_id))?;
+    Ok(bit_from_slot(slot))
+}
+
+/// Return every version whose `bit_slot` is set in `bits`, newest first.
+pub fn versions_for_bits(conn: &rusqlite::Connection, bits: i64) -> Result<Vec<Version>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, name, branch, parent_id, description, created_at, is_merged \
+         FROM kg_versions WHERE (?1 & (1 << bit_slot)) != 0 ORDER BY created_at DESC",
+    )?;
+    let rows = stmt.query_map([bits], row_to_version)?;
+    let mut versions = Vec::new();
+    for row in rows {
+        versions.push(row?);
+    }
+    Ok(versions)
+}
+
+/// List versions, optionally filtered by branch.
+pub fn list_versions(conn: &rusqlite::Connection, branch: Option<&str>) -> Result<Vec<Version>> {
+    let query = if branch.is_some() {
+        "SELECT id, name, branch, parent_id, description, created_at, is_merged \
+         FROM kg_versions WHERE branch = ?1 ORDER BY created_at DESC"
+    } else {
+        "SELECT id, name, branch, parent_id, description, created_at, is_merged \
+         FROM kg_versions ORDER BY created_at DESC"
+    };
+
+    let mut stmt = conn.prepare(query)?;
+
+    let rows = if let Some(b) = branch {
+        stmt.query_map(params![b], row_to_version)?
+    } else {
+        stmt.query_map([], row_to_version)?
+    };
+
+    let mut versions = Vec::new();
+    for row in rows {
+        versions.push(row?);
+    }
+    Ok(versions)
+}
+
+/// Get a version by ID. Returns None if not found.
+pub fn get_version(conn: &rusqlite::Connection, version_id: i64) -> Result<Version> {
+    conn.query_row(
+        "SELECT id, name, branch, parent_id, description, created_at, is_merged \
+         FROM kg_versions WHERE id = ?1",
+        [version_id],
+        row_to_version,
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Error::VersionNotFound(version_id),
+        other => Error::from(other),
+    })
+}
+
+/// Check that a version exists. Returns error if not found.
+pub fn ensure_version_exists(conn: &rusqlite::Connection, version_id: i64) -> Result<()> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM kg_versions WHERE id = ?1",
+            [version_id],
+            |r| r.get(0),
+        )
+        .map_err(Error::from)?;
+    if !exists {
+        return Err(Error::VersionNotFound(version_id));
+    }
+    Ok(())
+}
+
+/// Check that an entity exists. Returns error if not found.
+pub fn ensure_entity_exists(conn: &rusqlite::Connection, entity_id: i64) -> Result<()> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM kg_entities WHERE id = ?1",
+            [entity_id],
+            |r| r.get(0),
+        )
+        .map_err(Error::from)?;
+    if !exists {
+        return Err(Error::EntityNotFound(entity_id));
+    }
+    Ok(())
+}
+
+/// Check that a relation exists. Returns error if not found.
+pub fn ensure_relation_exists(conn: &rusqlite::Connection, relation_id: i64) -> Result<()> {
+    let exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM kg_relations WHERE id = ?1",
+        [relation_id],
+        |r| r.get(0),
+    )?;
+    if !exists {
+        return Err(Error::RelationNotFound(relation_id));
+    }
+    Ok(())
+}
+
+fn row_to_version(row: &rusqlite::Row) -> rusqlite::Result<Version> {
+    Ok(Version {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        branch: row.get(2)?,
+        parent_id: row.get(3)?,
+        description: row.get(4)?,
+        created_at: row.get(5)?,
+        is_merged: row.get::<_, i64>(6)? != 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::schema::create_schema(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_create_version() {
+        let conn = setup();
+        let id = create_version(&conn, "v1", "main", None, Some("first")).unwrap();
+        assert!(id > 0);
+
+        let v = get_version(&conn, id).unwrap();
+        assert_eq!(v.name, "v1");
+        assert_eq!(v.branch, "main");
+        assert_eq!(v.description.as_deref(), Some("first"));
+        assert!(!v.is_merged);
+    }
+
+    #[test]
+    fn test_duplicate_name_rejected() {
+        let conn = setup();
+        create_version(&conn, "v1", "main", None, None).unwrap();
+        let err = create_version(&conn, "v1", "main", None, None).unwrap_err();
+        assert!(matches!(err, Error::DuplicateVersionName(_)));
+    }
+
+    #[test]
+    fn test_delete_version() {
+        let conn = setup();
+        let id = create_version(&conn, "v1", "main", None, None).unwrap();
+        delete_version(&conn, id).unwrap();
+        assert!(get_version(&conn, id).is_err());
+    }
+
+    #[test]
+    fn test_delete_nonexistent() {
+        let conn = setup();
+        let err = delete_version(&conn, 999).unwrap_err();
+        assert!(matches!(err, Error::VersionNotFound(999)));
+    }
+
+    #[test]
+    fn test_list_all_versions() {
+        let conn = setup();
+        create_version(&conn, "v1", "main", None, None).unwrap();
+        create_version(&conn, "v2", "main", None, None).unwrap();
+        create_version(&conn, "v1-feat", "feature", None, None).unwrap();
+
+        let all = list_versions(&conn, None).unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn test_list_by_branch() {
+        let conn = setup();
+        create_version(&conn, "v1", "main", None, None).unwrap();
+        create_version(&conn, "v2", "main", None, None).unwrap();
+        create_version(&conn, "v1-feat", "feature", None, None).unwrap();
+
+        let main = list_versions(&conn, Some("main")).unwrap();
+        assert_eq!(main.len(), 2);
+        assert!(main.iter().all(|v| v.branch == "main"));
+    }
+
+    fn add_entity(conn: &Connection) -> i64 {
+        conn.execute(
+            "INSERT INTO kg_entities (entity_type, name) VALUES ('t', 'X')",
+            [],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn validity(conn: &Connection, eid: i64) -> Option<i64> {
+        conn.query_row(
+            "SELECT validity FROM kg_entities WHERE id = ?1",
+            [eid],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_first_version_uses_slot_zero() {
+        let conn = setup();
+        let id = create_version(&conn, "v1", "main", None, None).unwrap();
+        assert_eq!(version_bit_for(&conn, id).unwrap(), 1); // 1 << 0
+    }
+
+    #[test]
+    fn test_delete_clears_bits_and_collapses_to_null() {
+        let conn = setup();
+        let eid = add_entity(&conn);
+        let v1 = create_version(&conn, "v1", "main", None, None).unwrap();
+        crate::version::snapshot::version_add_entity(&conn, v1, eid).unwrap();
+        assert_eq!(validity(&conn, eid), Some(1));
+
+        delete_version(&conn, v1).unwrap();
+        // The only version is gone, so the entity returns to unversioned (NULL).
+        assert_eq!(validity(&conn, eid), None);
+    }
+
+    #[test]
+    fn test_slot_reclaimed_without_leaking_stale_bits() {
+        let conn = setup();
+        let eid = add_entity(&conn);
+        let v1 = create_version(&conn, "v1", "main", None, None).unwrap();
+        crate::version::snapshot::version_add_entity(&conn, v1, eid).unwrap();
+
+        // Deleting v1 frees slot 0; the next version must reuse it cleanly.
+        delete_version(&conn, v1).unwrap();
+        let v2 = create_version(&conn, "v2", "main", None, None).unwrap();
+        assert_eq!(version_bit_for(&conn, v2).unwrap(), 1); // slot 0 reused
+
+        // The entity must NOT have leaked into v2 via the recycled bit.
+        let in_v2 = crate::version::query::version_entities(&conn, v2, None, None).unwrap();
+        assert!(in_v2.is_empty());
+    }
+
+    #[test]
+    fn test_version_limit_exceeded() {
+        let conn = setup();
+        for i in 0..64 {
+            create_version(&conn, &format!("v{i}"), "main", None, None).unwrap();
+        }
+        let err = create_version(&conn, "v64", "main", None, None).unwrap_err();
+        assert!(matches!(err, Error::VersionLimitExceeded));
+    }
+
+    #[test]
+    fn test_version_bit_for_unknown_errors() {
+        let conn = setup();
+        let err = version_bit_for(&conn, 999).unwrap_err();
+        assert!(matches!(err, Error::VersionNotFound(999)));
+    }
+}

--- a/src/version/store.rs
+++ b/src/version/store.rs
@@ -87,6 +87,11 @@ pub fn version_bit_for(conn: &rusqlite::Connection, version_id: i64) -> Result<i
         )
         .optional()?
         .ok_or(Error::VersionNotFound(version_id))?;
+    // Guard against a corrupted/manual DB row: `bit_from_slot` shifts by `slot`,
+    // which panics for out-of-range values. Return an error instead.
+    if !(0..MAX_VERSIONS).contains(&slot) {
+        return Err(Error::CorruptBitSlot { version_id, slot });
+    }
     Ok(bit_from_slot(slot))
 }
 
@@ -338,5 +343,20 @@ mod tests {
         let conn = setup();
         let err = version_bit_for(&conn, 999).unwrap_err();
         assert!(matches!(err, Error::VersionNotFound(999)));
+    }
+
+    #[test]
+    fn test_version_bit_for_corrupt_slot_errors() {
+        let conn = setup();
+        let id = create_version(&conn, "v1", "main", None, None).unwrap();
+
+        // Simulate a corrupted/manual row by bypassing the CHECK constraint so the
+        // out-of-range slot reaches the read path instead of being rejected at write.
+        conn.execute_batch("PRAGMA ignore_check_constraints = ON").unwrap();
+        conn.execute("UPDATE kg_versions SET bit_slot = 64 WHERE id = ?1", [id])
+            .unwrap();
+
+        let err = version_bit_for(&conn, id).unwrap_err();
+        assert!(matches!(err, Error::CorruptBitSlot { version_id, slot } if version_id == id && slot == 64));
     }
 }

--- a/src/version/store.rs
+++ b/src/version/store.rs
@@ -134,7 +134,7 @@ pub fn list_versions(conn: &rusqlite::Connection, branch: Option<&str>) -> Resul
     Ok(versions)
 }
 
-/// Get a version by ID. Returns None if not found.
+/// Get a version by ID. Returns [`Error::VersionNotFound`] if no such version exists.
 pub fn get_version(conn: &rusqlite::Connection, version_id: i64) -> Result<Version> {
     conn.query_row(
         "SELECT id, name, branch, parent_id, description, created_at, is_merged \

--- a/src/version/store.rs
+++ b/src/version/store.rs
@@ -1,6 +1,6 @@
 //! Version CRUD operations.
 
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{ffi, params, OptionalExtension};
 
 use super::{bit_from_slot, Version, MAX_VERSIONS};
 use crate::error::{Error, Result};
@@ -23,14 +23,18 @@ pub fn create_version(
          VALUES (?1, ?2, ?3, ?4, ?5)",
         params![name, branch, parent_id, description, slot],
     )
-    .map_err(|e| {
-        if e.to_string()
-            .contains("UNIQUE constraint failed: kg_versions.name")
+    .map_err(|e| match e {
+        // Map the name UNIQUE violation to a typed error. Match the structured
+        // extended code rather than the English message text (which varies by
+        // SQLite/rusqlite version and locale); the `table.column` identifier is
+        // SQLite-generated and distinguishes it from the bit_slot UNIQUE column.
+        rusqlite::Error::SqliteFailure(err, Some(msg))
+            if err.extended_code == ffi::SQLITE_CONSTRAINT_UNIQUE
+                && msg.contains("kg_versions.name") =>
         {
             Error::DuplicateVersionName(name.to_string())
-        } else {
-            Error::from(e)
         }
+        other => Error::from(other),
     })?;
     Ok(conn.last_insert_rowid())
 }


### PR DESCRIPTION
## Summary

Adds bitstring-based **graph versioning** to the knowledge graph (QuaQue, arXiv:2603.18654). Migration **v4** introduces a `kg_versions` table and a `validity` bitstring column on `kg_entities`/`kg_relations`. Each version owns a reclaimable `bit_slot` in `[0, 63]`; version membership is an O(1) bitwise filter, with no data duplication.

All functionality is **additive** — existing API signatures and on-disk databases are unchanged (`validity=NULL` ⇒ unversioned, visible in every query).

## Capabilities

- **store** — create / delete / list versions; lowest-free-slot allocation
- **snapshot** — add / remove / bulk-assign entities & relations to versions
- **query** — version-filtered entities, relations, neighbor traversal
- **diff** — compare two versions; per-entity version history
- **merge** — union / intersection into a new version (transactional)
- `kg_bit_count()` SQL function for version-aware aggregation

`KnowledgeGraph` gains ~15 `version_*` methods; `lib.rs` re-exports `Version`, `VersionDiff`, `MergeStrategy`.

## Key design decisions

- **Reclaimable `bit_slot`, not `version_id`** — bit position is a slot freed on delete, so the limit is **64 *concurrent*** versions and bit shifts can never overflow (an earlier `1 << (id-1)` formulation panicked/aliased at the 65th lifetime creation). Exhaustion returns a clean `VersionLimitExceeded`.
- **`delete_version` clears the version's bit** from every row in one transaction, so a recycled slot never inherits stale membership.
- **`parent_id ... ON DELETE SET NULL`** — a merged version's source can still be deleted (and its slot reclaimed) instead of hitting an FK `RESTRICT`.
- **Atomic merge** — new version, `is_merged` flag, and validity updates run in a single transaction; intersection is a single set-based `UPDATE`.
- **`kg_bit_count` registered on both surfaces** — rusqlite (`KnowledgeGraph::open*`) and the loadable extension (`.load`).

## Test plan

- [x] `cargo test` — 183 passed, 0 failed
- [x] `cargo test --features async` — 201 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` (sync + async) — clean
- [x] `cargo fmt -- --check` — clean
- [x] 37 version unit tests: CRUD, slot reclamation w/o membership leak, 64-version limit, bitwise diff/merge, version-aware traversal, parent-delete slot reclamation