### PR TITLE
feat: QuaQue knowledge-graph versioning (arXiv:2603.18654) — v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.0] - 2026-05-21
+
+### Added
+
+- **QuaQue versioning** (`src/version/`) — based on arXiv:2603.18654
+  - Bitstring validity model: each entity/relation row carries a `validity` INTEGER; membership test is `(validity & (1 << bit_slot)) != 0`
+  - Up to 64 concurrent named versions via reclaimable `bit_slot` allocation (slots freed on delete, lowest free slot always reused)
+  - `create_version` / `delete_version` / `get_version` / `list_versions` — version CRUD
+  - `version_add_entity` / `version_remove_entity` / `version_add_relation` / `version_remove_relation` — snapshot membership management
+  - `version_snapshot_entities` / `version_snapshot_relations` — bulk snapshot of all current rows into a version
+  - `version_entities` / `version_relations` / `version_neighbors` — version-filtered queries with optional pagination
+  - `version_compare` — diff two versions: returns `VersionDiff` with added/removed/common entities and relations
+  - `version_entity_history` — all versions a given entity belongs to (newest first)
+  - `version_merge` — merge one or more source versions into a new target version with Union or Intersection strategy
+  - `Version`, `VersionDiff`, `MergeStrategy` public types
+- **Schema migration v4** — non-destructive; adds `kg_versions` table and `validity` column to `kg_entities` / `kg_relations`
+  - `kg_versions.bit_slot CHECK (bit_slot BETWEEN 0 AND 63)` — DB-level guard against out-of-range slot values
+
+### Fixed
+
+- `bit_from_slot` now returns `Option<i64>` — previously relied on `debug_assert!` (omitted in release builds); out-of-range slots now surface as `Error::CorruptBitSlot` instead of panicking on `1 << slot`
+- `create_version` detects duplicate names via structured `rusqlite::Error::SqliteFailure` extended error code + `table.column` identifier instead of brittle English message substring matching
+- `load_relations` diff reuses a single prepared statement across all IDs (eliminated per-iteration SQL recompile)
+- `load_entities` diff batches via `WHERE id IN (...)` queries (chunked at 900 IDs, removes N+1 pattern)
+- `get_version` doc comment corrected: function returns `Error::VersionNotFound`, not `None`
+
+### Technical
+
+- Schema version: v4
+- 177 unit tests passing
+
+---
+
 ## [0.12.0] - 2026-05-20
 
 ### Added
@@ -432,6 +465,7 @@ sqlite-kg search "brain network" --k 5 --db kg.db
 
 | Version | Date | Key Features |
 |---------|------|--------------|
+| 0.13.0 | 2026-05-21 | QuaQue bitstring versioning, version diff/merge, schema v4 |
 | 0.12.0 | 2026-05-20 | SmartVector: temporal confidence, four-signal retrieval, ripple propagation |
 | 0.11.0 | 2026-04-06 | Async API (tokio spawn_blocking) |
 | 0.10.3 | 2026-04-02 | Schema auto-migration, cache invalidation upgrade |
@@ -450,7 +484,8 @@ sqlite-kg search "brain network" --k 5 --db kg.db
 
 ---
 
-[Unreleased]: https://github.com/hiyenwong/sqlite-knowledge-graph/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/hiyenwong/sqlite-knowledge-graph/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/hiyenwong/sqlite-knowledge-graph/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/hiyenwong/sqlite-knowledge-graph/compare/v0.11.1...v0.12.0
 [0.11.0]: https://github.com/hiyenwong/sqlite-knowledge-graph/compare/v0.10.3...v0.11.0
 [0.10.3]: https://github.com/hiyenwong/sqlite-knowledge-graph/compare/v0.10.2...v0.10.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,7 +1223,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlite-knowledge-graph"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-knowledge-graph"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Hi Yen Wong"]
 description = "A Rust library for building and querying knowledge graphs using SQLite as the backend, with graph algorithms, vector search, and RAG support"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ A Rust library for building and querying knowledge graphs using SQLite as the ba
 - **Ripple Propagation**: BFS confidence penalty propagation along dependency edges (2 hops, 0.5× attenuation)
 - **Audit Log**: Full `kg_confidence_log` history with FK cascade and composite index
 
+### QuaQue Versioning ✅ *(v0.13.0)*
+- **Bitstring validity model**: each entity/relation row carries a `validity` INTEGER column; `(validity & (1 << bit_slot)) != 0` determines membership — based on arXiv:2603.18654
+- **64 concurrent named versions**: reclaimable `bit_slot` allocation (slots freed on delete, lowest free slot reused)
+- **Version CRUD**: `create_version`, `delete_version`, `get_version`, `list_versions`
+- **Snapshot management**: add/remove individual entities and relations, or bulk-snapshot all current rows
+- **Version-filtered queries**: `version_entities`, `version_relations`, `version_neighbors`
+- **Diff**: `version_compare` returns added/removed/common entities and relations between two versions
+- **History**: `version_entity_history` — all versions a given entity belongs to
+- **Merge**: `version_merge` with Union or Intersection strategy
+
 ### RAG Integration ✅
 - **Two-Stage Retrieval**: TurboQuant ANN (Stage 1) → exact cosine rerank (Stage 2) — *MemRL*
 - **Graph Expansion**: BFS-based candidate expansion via graph neighbours — *RAPO*
@@ -169,6 +179,12 @@ impl KnowledgeGraph {
     pub fn smart_search(&self, query: Vec<f32>, k: usize) -> Result<Vec<SmartSearchResult>>
     pub fn set_retrieval_weights(&self, weights: RetrievalWeights)
     pub fn retrieval_weights(&self) -> RetrievalWeights
+
+    // QuaQue versioning
+    pub fn version_create(&self, name: &str, branch: &str) -> Result<i64>       // via version::store
+    pub fn version_add_entity(&self, version_id: i64, entity_id: i64) -> Result<()>
+    pub fn version_compare(&self, v1_id: i64, v2_id: i64) -> Result<VersionDiff>
+    pub fn version_merge(&self, source_ids: &[i64], name: &str, strategy: MergeStrategy) -> Result<i64>
 
     // Legacy RAG helpers (simple, no graph expansion)
     pub fn kg_semantic_search(&self, query_embedding: Vec<f32>, k: usize) -> Result<Vec<SearchResultWithEntity>>


### PR DESCRIPTION
## Summary

- **QuaQue bitstring versioning** — condensed relational model where each entity/relation row carries a `validity` INTEGER column; membership in a version is tested with `(validity & (1 << bit_slot)) != 0` (arXiv:2603.18654)
- Up to 64 concurrent named versions via reclaimable `bit_slot` allocation; slots freed on delete and recycled (lowest free slot reused)
- Full version lifecycle: create, delete, list, diff, merge (Union / Intersection), entity/relation history
- Schema migration v4 — non-destructive; adds `kg_versions` table and `validity` column to `kg_entities` / `kg_relations`

## New API (`src/version/`)

| Function | Description |
|----------|-------------|
| `store::create_version` / `delete_version` / `get_version` / `list_versions` | Version CRUD |
| `snapshot::version_add_entity` / `version_remove_entity` | Membership management |
| `snapshot::version_snapshot_entities` / `version_snapshot_relations` | Bulk snapshot of current rows |
| `query::version_entities` / `version_relations` / `version_neighbors` | Version-filtered queries |
| `diff::version_compare` | Diff two versions → `VersionDiff` (added/removed/common) |
| `diff::version_entity_history` | All versions an entity belongs to |
| `merge::version_merge` | Merge sources into a new version with Union or Intersection |

## Fixes & improvements (PR review follow-ups)

- `bit_from_slot` returns `Option<i64>` — out-of-range slots return `Error::CorruptBitSlot` instead of panicking in release builds
- `kg_versions.bit_slot CHECK (bit_slot BETWEEN 0 AND 63)` — schema-level guard
- `create_version` detects duplicate names via structured `SqliteFailure` extended error code, not brittle English message matching
- `load_relations` diff: prepared statement hoisted outside loop (eliminates per-iteration recompile)
- `load_entities` diff: batched `WHERE id IN (...)` queries, chunked at 900 IDs (removes N+1)
- `get_version` docstring corrected

## Test plan

- [ ] `cargo test --lib` — 177 tests passing
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `cargo fmt --check` — no formatting drift
- [ ] All 7 Copilot review comments addressed (see individual thread replies)
- [ ] Tag `v0.13.0` pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)